### PR TITLE
Add setting and checking of non_got_ref flag.

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,10 @@
+2014-11-18  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* elf32-arc.c (elf_arc_check_relocs): Set non_got_ref when
+	appropriate.
+	(elf_arc_adjust_dynamic_symbol): Check non_got_ref when
+	appropriate.
+
 2014-05-23  Joern Rennecke  <joern.rennecke@embecosm.com>
 
 	* elf32-arc.c (arc_tls_transition) <R_ARC_TLS_IE_GOT -> GOT_TLS_LE>:

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -2304,6 +2304,13 @@ elf_arc_check_relocs (bfd *abfd,
 	      bfd_set_error (bfd_error_bad_value);
 	      return FALSE;
 	    }
+
+          /* In some cases we are not setting the 'non_got_ref' flag, even
+             though the relocations don't require a GOT access.  We should
+             extend the testing in this area to ensure that no significant
+             cases are being missed.  */
+          if (h)
+            h->non_got_ref = 1;
 	  /* FALLTHROUGH */
 	case R_ARC_PC32:
 	case R_ARC_32_PCREL:
@@ -3782,6 +3789,11 @@ elf_arc_adjust_dynamic_symbol (struct bfd_link_info *info,
       h->root.u.def.value = h->u.weakdef->root.u.def.value;
       return TRUE;
     }
+
+  /* If there are no non-GOT references, we do not need a copy
+     relocation.  */
+  if (!h->non_got_ref)
+    return TRUE;
 
   /* This is a reference to a symbol defined by a dynamic object which
      is not a function.  */


### PR DESCRIPTION
Make use of the non_got_ref as other targets do.

bfd/ChangeLog:

```
* elf32-arc.c (elf_arc_check_relocs): Set non_got_ref when
appropriate.
(elf_arc_adjust_dynamic_symbol): Check non_got_ref when
appropriate.
```
