### PR TITLE
Avoid creating invalid relocations when --gc-sections is used in the linker.

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2014-12-02 Andrew Burgess <andrew.burgess@embecosm.com>
+
+	* elf32-arc.c (elf_arc_finish_dynamic_symbol): Don't generate
+	R_ARC_GLOB_DAT relocations for symbols that have been removed.
+
 2014-10-21 Claudiu Zissulescu <claziss@synopsys.com>
 
 	* elf32-arc.c (arc_elf_object_p): Throw a warning/error only

--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2014-12-14 Andrew Burgess <andrew.burgess@embecosm.com>
+
+	* elf32-arc.c (elf_arc_size_dynamic_sections): Zero initialise
+	contents of dynamic sections before use.
+
 2014-12-02 Andrew Burgess <andrew.burgess@embecosm.com>
 
 	* elf32-arc.c (elf_arc_finish_dynamic_symbol): Don't generate

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -2720,6 +2720,8 @@ elf_arc_finish_dynamic_symbol (bfd *output_bfd,
 	  rel.r_addend = 0;
 	  rel.r_info = ELF32_R_INFO (0, R_ARC_RELATIVE);
 	}
+      else if (h->dynindx == -1)
+        memset (&rel, 0, sizeof rel);
       else
 	{
 	  bfd_put_32 (output_bfd, (bfd_vma) 0, sgot->contents + h->got.offset);

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -3365,7 +3365,7 @@ elf_arc_size_dynamic_sections (bfd *output_bfd,
 	}
 
       /* Allocate memory for the section contents.  */
-      s->contents = (bfd_byte *) bfd_alloc (dynobj, s->size);
+      s->contents = (bfd_byte *) bfd_zalloc (dynobj, s->size);
       if (s->contents == NULL && s->size != 0)
 	return FALSE;
     }


### PR DESCRIPTION
The two changes in this tree avoid creating invalid relocation when `--gc-sections` is used by the linker, however, instead we create R_ARC_NONE relocations, which may not be acceptable.

I believe that the real problem is that ARC sizes the relocation sections inside `elf_arc_check_relocs`, which is before garbage collection has occurred.  Later functions don't then take sufficient account of the fact that sections, and the symbols within them might have been removed.  Targets like ARM and X86-64 leave sizing of the relocation containing sections to much later in the process, after garbage collection has been performed, which helps with many of these problems.

Neither of these fixes are ideal, and should be revisited as part of a bigger task; reworking how we manage the size of the relocation holding sections.  However, I believe that both of these changes are safe and correct, and should allow `--gc-sections` to be used safely.

Given that I'm unlikely to be able to spend much time on this until next month now I'll leave the choice on whether to merge these fixes now, or wait for a better fix (one that avoids `R_ARC_NONE`) up to others.