### PR TITLE
Fix linker tests which use shared libraries

### DIFF
--- a/ld/testsuite/ld-arc/arc.exp
+++ b/ld/testsuite/ld-arc/arc.exp
@@ -22,25 +22,27 @@
 # ARC specific tests.
 #
 
-if {![istarget arc-*-*]} {
+if {![istarget "arc*-*-*"]} {
     return
 }
 
-# Create an empty shared library that can be linked into some of these
-# tests.
-run_ld_link_tests [list \
-    [list \
-         "Build ARC700 (EA) dummy shared library" \
-         "-shared" \
-         "-mARC700 -mEA" \
-         { dummy-lib.s } \
-         {} \
-         "libdummy.so.0" \
-    ] \
-]
 
-set arc_test_list [lsort [glob -nocomplain $srcdir/$subdir/*.d]]
-foreach arc_test $arc_test_list {
-    verbose [file rootname $arc_test]
-    run_dump_test [file rootname $arc_test]
+if {[check_shared_lib_support]} {
+    # Create an empty shared library that can be linked into
+    # some of these tests.
+    run_ld_link_tests [list \
+	[list \
+	    "Build ARC700 (EA) dummy shared library" \
+	    "-shared" \
+	    "-mARC700 -mEA" \
+	    { dummy-lib.s } \
+	    {} \
+	    "libdummy.so.0" \
+	] \
+    ]
+    run_dump_test "gc-sections1"
+    run_dump_test "gotpc1"
+    run_dump_test "gotpc2"
 }
+
+run_dump_test "sda_relocs"

--- a/ld/testsuite/ld-elf/indirect.exp
+++ b/ld/testsuite/ld-elf/indirect.exp
@@ -1,5 +1,5 @@
 # Expect script for various indirect symbol tests.
-#   Copyright 2012 Free Software Foundation, Inc.
+#   Copyright (C) 2012-2014 Free Software Foundation, Inc.
 #
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,8 +26,19 @@ if ![is_elf_format] {
     return
 }
 
+# Skip target where -shared is not supported
+
+if ![check_shared_lib_support] {
+    return
+}
+
 # Check if compiler works
 if { [which $CC] == 0 } {
+    return
+}
+
+# Some bare-metal targets don't support shared libs or PIC.
+if { ![run_host_cmd_yesno $CC "-shared -fPIC $srcdir/$subdir/dummy.c -o tmpdir/t.so"] } {
     return
 }
 

--- a/ld/testsuite/lib/ld-lib.exp
+++ b/ld/testsuite/lib/ld-lib.exp
@@ -1545,7 +1545,7 @@ proc check_gc_sections_available { } {
 # Only used and accurate for ELF targets at the moment
 
 proc check_shared_lib_support { } {
-    if {![istarget arc*-*-*]
+    if {![istarget arc*-*-elf32]
 	 && ![istarget avr-*-*]
 	 && ![istarget cr16-*-*]
 	 && ![istarget cris*-*-*]


### PR DESCRIPTION
There are some tests which fail on bare metal ARC targets:

    ld/testsuite/ld-arc/arc.exp
    ld/testsuite/ld-elf/indirect.exp

They fail because they are intended for targets with support of shared libraries. However these tests don't check whether a particular ARC target is bare metal or not.

Also `check_shared_lib_support` function from `ld/testsuite/lib/ld-lib.exp` is incorrect. Even appropriate ARC targets are skipped in tests where this function is used (e.g. `arc-archs-linux-uclibc`).

For `ld/testsuite/ld-elf/indirect.exp` I imported changes from the upstream repository of binutils.