### PR TITLE
Fix linker tests which use shared libraries

### DIFF
--- a/ld/testsuite/ChangeLog
+++ b/ld/testsuite/ChangeLog
@@ -139,6 +139,12 @@
 	* ld-ifunc/ifunc-14d-i386.d: Likewise.
 	* ld-ifunc/ifunc-14d-x86-64.d: Likewise.
 
+2012-12-14  Yufeng Zhang  <yufeng.zhang@arm.com>
+
+        * ld-elf/indirect.exp: Disable if -shared is not supported.
+        * lib/ld-lib.exp (check_shared_lib_support): Add aarch64*-*-elf and
+        arm*-*-elf to the exclude list.
+
 2012-11-30  Roland McGrath  <mcgrathr@google.com>
 
 	* ld-elf/ehdr_start.s: Put reference in .rodata section, not .data.

--- a/ld/testsuite/ld-arc/arc.exp
+++ b/ld/testsuite/ld-arc/arc.exp
@@ -22,25 +22,27 @@
 # ARC specific tests.
 #
 
-if {![istarget arc-*-*]} {
+if {![istarget "arc*-*-*"]} {
     return
 }
 
-# Create an empty shared library that can be linked into some of these
-# tests.
-run_ld_link_tests [list \
-    [list \
-         "Build ARC700 (EA) dummy shared library" \
-         "-shared" \
-         "-mARC700 -mEA" \
-         { dummy-lib.s } \
-         {} \
-         "libdummy.so.0" \
-    ] \
-]
 
-set arc_test_list [lsort [glob -nocomplain $srcdir/$subdir/*.d]]
-foreach arc_test $arc_test_list {
-    verbose [file rootname $arc_test]
-    run_dump_test [file rootname $arc_test]
+if {[check_shared_lib_support]} {
+    # Create an empty shared library that can be linked into
+    # some of these tests.
+    run_ld_link_tests [list \
+	[list \
+	    "Build ARC700 (EA) dummy shared library" \
+	    "-shared" \
+	    "-mARC700 -mEA" \
+	    { dummy-lib.s } \
+	    {} \
+	    "libdummy.so.0" \
+	] \
+    ]
+    run_dump_test "gc-sections1"
+    run_dump_test "gotpc1"
+    run_dump_test "gotpc2"
 }
+
+run_dump_test "sda_relocs"

--- a/ld/testsuite/ld-elf/indirect.exp
+++ b/ld/testsuite/ld-elf/indirect.exp
@@ -26,6 +26,12 @@ if ![is_elf_format] {
     return
 }
 
+# Skip target where -shared is not supported
+
+if ![check_shared_lib_support] {
+    return
+}
+
 # Check if compiler works
 if { [which $CC] == 0 } {
     return

--- a/ld/testsuite/lib/ld-lib.exp
+++ b/ld/testsuite/lib/ld-lib.exp
@@ -1545,7 +1545,7 @@ proc check_gc_sections_available { } {
 # Only used and accurate for ELF targets at the moment
 
 proc check_shared_lib_support { } {
-    if {![istarget arc*-*-*]
+    if {![istarget arc*-*-elf32]
 	 && ![istarget avr-*-*]
 	 && ![istarget cr16-*-*]
 	 && ![istarget cris*-*-*]

--- a/ld/testsuite/lib/ld-lib.exp
+++ b/ld/testsuite/lib/ld-lib.exp
@@ -1545,7 +1545,9 @@ proc check_gc_sections_available { } {
 # Only used and accurate for ELF targets at the moment
 
 proc check_shared_lib_support { } {
-    if {![istarget arc*-*-elf32]
+    if {![istarget aarch64*-*-elf]
+	 && ![istarget arc*-*-elf32]
+	 && ![istarget arm*-*-elf]
 	 && ![istarget avr-*-*]
 	 && ![istarget cr16-*-*]
 	 && ![istarget cris*-*-*]


### PR DESCRIPTION
There are some tests which fail on bare metal ARC targets:

    ld/testsuite/ld-arc/arc.exp
    ld/testsuite/ld-elf/indirect.exp

They fail because they are intended for targets with support of shared libraries. However these tests don't check whether a particular ARC target is bare metal or not.

Also `check_shared_lib_support` function from `ld/testsuite/lib/ld-lib.exp` is incorrect. Even appropriate ARC targets are skipped in tests where this function is used (e.g. `arc-archs-linux-uclibc`).

For `ld/testsuite/ld-elf/indirect.exp` I cherry picked changes from the upstream repository of binutils. Read commit's comment for explanation: https://github.com/foss-for-synopsys-dwc-arc-processors/binutils-gdb/commit/8986f9b255ed406df75b8caf7f4d9cdebb538c92.