### PR TITLE
arc/gdb support building on gcc 5x

### DIFF
--- a/sim/common/ChangeLog.ARC
+++ b/sim/common/ChangeLog.ARC
@@ -1,3 +1,10 @@
+2015-03-31  Mike Frysinger  <vapier@gentoo.org>
+
+	Cherry pick commit 5a394431deb3745c04a74d2a109aca075f79afd6 from
+	upstream.
+	* cgen-mem.h (MEMOPS_INLINE): Change to EXTERN_INLINE.
+	* cgen-ops.h (SEMOPS_INLINE): Likewise.
+
 2015-03-29  Mike Frysinger  <vapier@gentoo.org>
 
 	Cherry pick commit 92fc6153a6fdf2a027d9780f5945712aafad4a9e from

--- a/sim/common/ChangeLog.ARC
+++ b/sim/common/ChangeLog.ARC
@@ -1,3 +1,11 @@
+2015-03-29  Mike Frysinger  <vapier@gentoo.org>
+
+	Cherry pick commit 92fc6153a6fdf2a027d9780f5945712aafad4a9e from
+	upstream.
+	* sim-arange.h (SIM_ARANGE_INLINE): Move above sim_addr_range_hit_p.
+	(sim_addr_range_hit_p): Change INLINE to SIM_ARANGE_INLINE.
+	* sim-inline.h (INLINE2): Define to gnu_inline when available.
+
 2013-03-17  Joern Rennecke  <joern.rennecke@embecosm.com>
 
 	* cgen-trace.c: Merge from;

--- a/sim/common/cgen-mem.h
+++ b/sim/common/cgen-mem.h
@@ -20,10 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #ifndef CGEN_MEM_H
 #define CGEN_MEM_H
 
+/* TODO: This should get moved into sim-inline.h.  */
 #ifdef MEMOPS_DEFINE_INLINE
 #define MEMOPS_INLINE
 #else
-#define MEMOPS_INLINE extern inline
+#define MEMOPS_INLINE EXTERN_INLINE
 #endif
 
 /* Integer memory read support.

--- a/sim/common/cgen-ops.h
+++ b/sim/common/cgen-ops.h
@@ -24,9 +24,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <assert.h>
 
+/* TODO: This should get moved into sim-inline.h.  */
 #if defined (__GNUC__) && ! defined (SEMOPS_DEFINE_INLINE)
 #define SEMOPS_DEFINE_INLINE
-#define SEMOPS_INLINE extern inline
+#define SEMOPS_INLINE EXTERN_INLINE
 #else
 #define SEMOPS_INLINE
 #endif

--- a/sim/common/sim-arange.h
+++ b/sim/common/sim-arange.h
@@ -60,22 +60,26 @@ extern void sim_addr_range_delete (ADDR_RANGE * /*ar*/,
 				   address_word /*start*/,
 				   address_word /*end*/);
 
-/* Return non-zero if ADDR is in range AR, traversing the entire tree.
-   If no range is specified, that is defined to mean "everything".  */
-extern INLINE int
-sim_addr_range_hit_p (ADDR_RANGE * /*ar*/, address_word /*addr*/);
-#define ADDR_RANGE_HIT_P(ar, addr) \
-  ((ar)->range_tree == NULL || sim_addr_range_hit_p ((ar), (addr)))
-
+/* TODO: This should get moved into sim-inline.h.  */
 #ifdef HAVE_INLINE
 #ifdef SIM_ARANGE_C
 #define SIM_ARANGE_INLINE INLINE
 #else
 #define SIM_ARANGE_INLINE EXTERN_INLINE
 #endif
-#include "sim-arange.c"
 #else
-#define SIM_ARANGE_INLINE
+#define SIM_ARANGE_INLINE EXTERN
+#endif
+
+/* Return non-zero if ADDR is in range AR, traversing the entire tree.
+   If no range is specified, that is defined to mean "everything".  */
+SIM_ARANGE_INLINE int
+sim_addr_range_hit_p (ADDR_RANGE * /*ar*/, address_word /*addr*/);
+#define ADDR_RANGE_HIT_P(ar, addr) \
+  ((ar)->range_tree == NULL || sim_addr_range_hit_p ((ar), (addr)))
+
+#ifdef HAVE_INLINE
+#include "sim-arange.c"
 #endif
 #define SIM_ARANGE_C_INCLUDED
 

--- a/sim/common/sim-inline.h
+++ b/sim/common/sim-inline.h
@@ -303,7 +303,9 @@
 /* ??? Temporary, pending decision to always use extern inline and do a vast
    cleanup of inline support.  */
 #ifndef INLINE2
-#if defined (__GNUC__)
+#if defined (__GNUC_GNU_INLINE__) || defined (__GNUC_STDC_INLINE__)
+#define INLINE2 __inline__ __attribute__ ((__gnu_inline__))
+#elif defined (__GNUC__)
 #define INLINE2 __inline__
 #else
 #define INLINE2 /*inline*/


### PR DESCRIPTION
After a recent compiler update (GCC 5.1.1) I was unable to build the arc-7.9-dev branch (and arc-7.5-dev too).  Turns out this issue has already been solved upstream, this pull request just cherry-picks the two required patches from upstream to fix this issue.