### PR TITLE
[ARC] Provide an interface to decode ARC instructions

### DIFF
--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -51,17 +51,20 @@ name_for_global_symbol (struct elf_link_hash_entry *h)
     Elf_Internal_Rela _rel;						\
     bfd_byte * _loc;							\
 									\
-    BFD_ASSERT (_htab->srel##SECTION &&_htab->srel##SECTION->contents); \
-    _loc = _htab->srel##SECTION->contents				\
-      + ((_htab->srel##SECTION->reloc_count)				\
-	 * sizeof (Elf32_External_Rela));				\
-    _htab->srel##SECTION->reloc_count++;				\
-    _rel.r_addend = ADDEND;						\
-    _rel.r_offset = (_htab->s##SECTION)->output_section->vma		\
-      + (_htab->s##SECTION)->output_offset + OFFSET;			\
-    BFD_ASSERT ((long) SYM_IDX != -1);					\
-    _rel.r_info = ELF32_R_INFO (SYM_IDX, TYPE);				\
-    bfd_elf32_swap_reloca_out (BFD, &_rel, _loc);			\
+    if(_htab->dynamic_sections_created == TRUE)				\
+      {									\
+	BFD_ASSERT (_htab->srel##SECTION &&_htab->srel##SECTION->contents); \
+    	_loc = _htab->srel##SECTION->contents				\
+    	  + ((_htab->srel##SECTION->reloc_count)			\
+    	     * sizeof (Elf32_External_Rela));				\
+    	_htab->srel##SECTION->reloc_count++;				\
+    	_rel.r_addend = ADDEND;						\
+    	_rel.r_offset = (_htab->s##SECTION)->output_section->vma	\
+    	  + (_htab->s##SECTION)->output_offset + OFFSET;		\
+    	BFD_ASSERT ((long) SYM_IDX != -1);				\
+    	_rel.r_info = ELF32_R_INFO (SYM_IDX, TYPE);			\
+    	bfd_elf32_swap_reloca_out (BFD, &_rel, _loc);			\
+      }									\
   }
 
 struct dynamic_sections

--- a/binutils/doc/binutils.texi
+++ b/binutils/doc/binutils.texi
@@ -2244,10 +2244,12 @@ For ARC, @option{dsp} controls the printing of DSP instructions,
 @option{spfp} selects the printing of FPX single precision FP
 instructions, @option{dpfp} selects the printing of FPX double
 precision FP instructions, @option{quarkse_em} selects the printing of
-special QuarkSE-EM instructions, @option{fpuda} selects the printing
-of double precision assist instructions, @option{fpus} selects the
-printing of FPU single precision FP instructions, while @option{fpud}
-selects the printing of FPU souble precision FP instructions.
+special QuarkSE-EM instructions, @option{quarkse2_em} selects the
+printing of special QuarkSE2-EM instructions, @option{fpuda} selects
+the printing of double precision assist instructions, @option{fpus}
+selects the printing of FPU single precision FP instructions, while
+@option{fpud} selects the printing of FPU souble precision FP
+instructions.
 
 If the target is an ARM architecture then this switch can be used to
 select which register name set is used during disassembler.  Specifying

--- a/binutils/readelf.c
+++ b/binutils/readelf.c
@@ -2407,6 +2407,9 @@ decode_ARC_machine_flags (unsigned e_flags, unsigned e_machine, char buf[])
     case E_ARC_OSABI_V3:
       strcat (buf, ", v3 no-legacy-syscalls ABI");
       break;
+    case E_ARC_OSABI_V4:
+      strcat (buf, ", v4 ABI");
+      break;
     default:
       strcat (buf, ", unrecognised ARC OSABI flag");
       break;

--- a/binutils/testsuite/binutils-all/arc/objdump.exp
+++ b/binutils/testsuite/binutils-all/arc/objdump.exp
@@ -46,7 +46,7 @@ if [is_remote host] {
 
 set got [binutils_run $OBJDUMP "$OBJDUMPFLAGS --disassemble $objfile"]
 
-set want "Warning: disassembly.*dsubh12\[ \t\]*r0,r2,r4.*dmulh12.f\[ \t\]*r0,r2,r4.*dmulh11.f"
+set want "Warning: disassembly.*vmac2hnfr\[ \t\]*r0,r2,r4.*dmulh12.f\[ \t\]*r0,r2,r4.*dmulh11.f"
 
 if [regexp $want $got] then {
     pass "Warning test"

--- a/include/elf/arc.h
+++ b/include/elf/arc.h
@@ -55,8 +55,12 @@ END_RELOC_NUMBERS (R_ARC_max)
 #define E_ARC_OSABI_ORIG	0x00000000   /* MUST be 0 for back-compat.  */
 #define E_ARC_OSABI_V2		0x00000200
 #define E_ARC_OSABI_V3		0x00000300
+#define E_ARC_OSABI_V4		0x00000400
+#ifdef __ARC_OSABI_V3
 #define E_ARC_OSABI_CURRENT	E_ARC_OSABI_V3
-
+#else
+#define E_ARC_OSABI_CURRENT	E_ARC_OSABI_V4
+#endif
 /* Leave bits 0xf0 alone in case we ever have more than 16 cpu types.  */
 
 /* File contains position independent code.  */

--- a/opcodes/arc-dis.c
+++ b/opcodes/arc-dis.c
@@ -129,21 +129,6 @@ static linkclass decodelist = NULL;
 
 /* Functions implementation.  */
 
-/* Return TRUE when two classes are not opcode conflicting.  */
-
-static bfd_boolean
-is_compatible_p (insn_class_t     classA,
-		 insn_subclass_t  sclassA,
-		 insn_class_t     classB,
-		 insn_subclass_t  sclassB)
-{
-  if (classA == DSP && sclassB == DPX)
-    return FALSE;
-  if (sclassA == DPX && classB == DSP)
-    return FALSE;
-  return TRUE;
-}
-
 /* Add a new element to the decode list.  */
 
 static void
@@ -162,53 +147,33 @@ add_to_decodelist (insn_class_t     insn_class,
    disassembled.  */
 
 static bfd_boolean
-skip_this_opcode (const struct arc_opcode *  opcode,
-		  struct disassemble_info *  info)
+skip_this_opcode (const struct arc_opcode *  opcode)
 {
   linkclass t = decodelist;
-  bfd_boolean addme = TRUE;
 
-  /* Check opcode for major 0x06, return if it is not in.  */
+  /* Check opcode for major 0x06, return if it is not.  */
   if (OPCODE (opcode->opcode) != 0x06)
     return FALSE;
 
-  while (t != NULL
-	 && is_compatible_p (t->insn_class, t->subclass,
-			     opcode->insn_class, opcode->subclass))
+  /* or not a known truble class.  */
+  switch (opcode->insn_class)
+    {
+    case FLOAT:
+    case DSP:
+      break;
+    default:
+      return FALSE;
+    }
+
+  while (t != NULL)
     {
       if ((t->insn_class == opcode->insn_class)
 	  && (t->subclass == opcode->subclass))
-	addme = FALSE;
+	return FALSE;
       t = t->nxt;
     }
 
-  /* If we found an incompatibility then we must skip.  */
-  if (t != NULL)
-    return TRUE;
-
-  /* Even if we do not precisely know the if the right mnemonics
-     is correctly displayed, keep the disassmbled code class
-     consistent.  */
-  if (addme)
-    {
-      switch (opcode->insn_class)
-	{
-	case DSP:
-	case FLOAT:
-	  /* Add to the conflict list only the classes which
-	     counts.  */
-	  add_to_decodelist (opcode->insn_class, opcode->subclass);
-	  /* Warn if we have to decode an opcode and no preferred
-	     classes have been chosen.  */
-	  info->fprintf_func (info->stream, _("\n\
-Warning: disassembly may be wrong due to guessed opcode class choice.\n\
- Use -M<class[,class]> to select the correct opcode class(es).\n\t\t\t\t"));
-	  break;
-	default:
-	  break;
-	}
-    }
-  return FALSE;
+  return TRUE;
 }
 
 static bfd_vma
@@ -263,8 +228,10 @@ find_format_from_table (struct disassemble_info *info,
 {
   unsigned int i = 0;
   const struct arc_opcode *opcode = NULL;
+  const struct arc_opcode *t_op = NULL;
   const unsigned char *opidx;
   const unsigned char *flgidx;
+  bfd_boolean warn_p = FALSE;
 
   do
     {
@@ -366,14 +333,28 @@ find_format_from_table (struct disassemble_info *info,
 	continue;
 
       if (insn_len == 4
-	  && overlaps
-	  && skip_this_opcode (opcode, info))
-	continue;
+	  && overlaps)
+	{
+	  warn_p = TRUE;
+	  t_op = opcode;
+	  if (skip_this_opcode (opcode))
+	    continue;
+	}
 
       /* The instruction is valid.  */
       return opcode;
     }
   while (opcode->mask);
+
+  if (warn_p)
+    {
+      info->fprintf_func (info->stream,
+			  _("\nWarning: disassembly may be wrong due to "
+			    "guessed opcode class choice.\n"
+			    "Use -M<class[,class]> to select the correct "
+			    "opcode class(es).\n\t\t\t\t"));
+      return t_op;
+    }
 
   return NULL;
 }
@@ -846,18 +827,22 @@ parse_option (char *option)
     add_to_decodelist (FLOAT, DPX);
 
   else if (CONST_STRNEQ (option, "quarkse_em"))
-    add_to_decodelist (FLOAT, QUARKSE);
+    {
+      add_to_decodelist (FLOAT, DPX);
+      add_to_decodelist (FLOAT, SPX);
+      add_to_decodelist (FLOAT, QUARKSE);
+    }
 
   else if (CONST_STRNEQ (option, "fpuda"))
     add_to_decodelist (FLOAT, DPA);
 
-  else if (CONST_STRNEQ (option, "fpud"))
+  else if (CONST_STRNEQ (option, "fpus"))
     {
       add_to_decodelist (FLOAT, SP);
       add_to_decodelist (FLOAT, CVT);
     }
 
-  else if (CONST_STRNEQ (option, "fpus"))
+  else if (CONST_STRNEQ (option, "fpud"))
     {
       add_to_decodelist (FLOAT, DP);
       add_to_decodelist (FLOAT, CVT);

--- a/opcodes/arc-dis.c
+++ b/opcodes/arc-dis.c
@@ -833,6 +833,15 @@ parse_option (char *option)
       add_to_decodelist (FLOAT, QUARKSE);
     }
 
+  else if (CONST_STRNEQ (option, "quarkse2_em"))
+    {
+      add_to_decodelist (DSP, NONE);
+      add_to_decodelist (FLOAT, DPA);
+      add_to_decodelist (FLOAT, SP);
+      add_to_decodelist (FLOAT, CVT);
+      add_to_decodelist (FLOAT, QUARKSE);
+    }
+
   else if (CONST_STRNEQ (option, "fpuda"))
     add_to_decodelist (FLOAT, DPA);
 
@@ -1277,6 +1286,8 @@ with -M switch (multiple options should be separated by commas):\n"));
   dpfp            Recognize FPX DP instructions.\n"));
   fprintf (stream, _("\
   quarkse_em      Recognize FPU QuarkSE-EM instructions.\n"));
+  fprintf (stream, _("\
+  quarkse2_em     Recognize FPU QuarkSE2-EM instructions.\n"));
   fprintf (stream, _("\
   fpuda           Recognize double assist FPU instructions.\n"));
   fprintf (stream, _("\

--- a/opcodes/arc-dis.h
+++ b/opcodes/arc-dis.h
@@ -107,6 +107,287 @@ struct arcDisState
 struct arcDisState
 arcAnalyzeInstr (bfd_vma memaddr, struct disassemble_info *);
 
+enum arc_ldst_writeback_mode
+  {
+    ARC_WRITEBACK_NO = 0,
+    ARC_WRITEBACK_AW = 1,
+    ARC_WRITEBACK_A = ARC_WRITEBACK_AW,
+    ARC_WRITEBACK_AB = 2,
+    ARC_WRITEBACK_AS = 3,
+  };
+
+
+enum arc_ldst_data_size
+  {
+    ARC_SCALING_NONE = 0,
+    ARC_SCALING_B = 1,
+    ARC_SCALING_H = 2,
+    ARC_SCALING_D = 3,
+  };
+
+
+enum arc_condition_code
+  {
+    ARC_CC_AL = 0x0,
+    ARC_CC_RA = ARC_CC_AL,
+    ARC_CC_EQ = 0x1,
+    ARC_CC_Z = ARC_CC_EQ,
+    ARC_CC_NE = 0x2,
+    ARC_CC_NZ = ARC_CC_NE,
+    ARC_CC_PL = 0x3,
+    ARC_CC_P = ARC_CC_PL,
+    ARC_CC_MI = 0x4,
+    ARC_CC_N = ARC_CC_MI,
+    ARC_CC_CS = 0x5,
+    ARC_CC_C = ARC_CC_CS,
+    ARC_CC_LO = ARC_CC_CS,
+    ARC_CC_CC = 0x6,
+    ARC_CC_NC = ARC_CC_CC,
+    ARC_CC_HS = ARC_CC_CC,
+    ARC_CC_VS = 0x7,
+    ARC_CC_V = ARC_CC_VS,
+    ARC_CC_VC = 0x8,
+    ARC_CC_NV = ARC_CC_VC,
+    ARC_CC_GT = 0x9,
+    ARC_CC_GE = 0xA,
+    ARC_CC_LT = 0xB,
+    ARC_CC_LE = 0xC,
+    ARC_CC_HI = 0xD,
+    ARC_CC_LS = 0xE,
+    ARC_CC_PNZ = 0xF,
+  };
+
+enum arc_operand_kind
+  {
+    ARC_OPERAND_KIND_UNKNOWN = 0,
+    ARC_OPERAND_KIND_REG,
+    ARC_OPERAND_KIND_SHIMM,
+    ARC_OPERAND_KIND_LIMM
+  };
+
+struct arc_insn_operand
+{
+  /* Operand value as encoded in instruction.  */
+  unsigned long value;
+
+  enum arc_operand_kind kind;
+};
+
+/* Only LEAVE_S can have this amount of operands.  Other instructions have 3
+   operands at most.  */
+#define ARC_MAX_OPERAND_COUNT (4)
+
+/* Container for information about instruction.  Provides a higher level access
+   to data that is contained in struct arc_opcode.  */
+
+struct arc_instruction
+{
+  /* Address of this instruction.  */
+  bfd_vma address;
+
+  /* Whether this is a valid instruction.  */
+  bfd_boolean valid;
+
+  insn_class_t insn_class;
+
+  /* Length (without LIMM).  */
+  unsigned int length;
+
+  /* Instruction word as it is, in the host endianness.  */
+  unsigned long raw_word;
+
+  /* Is there a LIMM in this instruction?  */
+  int limm_p;
+
+  /* Long immediate value.  */
+  unsigned long limm_value;
+
+  /* Some ARC instructions have subopcodes nested up to 3 layers.  */
+  unsigned int opcode;
+  unsigned int subopcode1;
+  unsigned int subopcode2;
+  unsigned int subopcode3;
+
+  /* Is it a branch/jump instruction?  */
+  int is_control_flow;
+
+  /* Whether this instruction has a delay slot.  */
+  int has_delay_slot;
+
+  /* Value of condition code field.  */
+  enum arc_condition_code condition_code;
+
+  /* Load/store writeback mode.  */
+  enum arc_ldst_writeback_mode writeback_mode;
+
+  /* Load/store data size.  */
+  enum arc_ldst_data_size data_size_mode;
+
+  /* Amount of operands in instruction.  Note that amount of operands reported
+     by opcodes disassembler can be different from the one encoded in the
+     instruction.  Notable case is "ld a,[b,offset]", when offset == 0.  In
+     this case opcodes disassembler presents this instruction as "ld a,[b]",
+     hence there are *two* operands, not three.  OPERANDS_COUNT and OPERANDS
+     contain only those explicit operands, hence it is up to invoker to handle
+     the case described above based on instruction opcodes.  Another notable
+     thing is that in opcodes disassembler representation square brackets (`['
+     and `]') are so called fake-operands - they are in the list of operands,
+     but do not have any value of they own.  Those "operands" are not present
+     in this array.  */
+  struct arc_insn_operand operands[ARC_MAX_OPERAND_COUNT];
+
+  unsigned int operands_count;
+};
+
+/* Fill INSN with data about instruction at specified ADDR.  */
+
+void arc_insn_decode (bfd_vma addr,
+		      struct disassemble_info *di,
+		      disassembler_ftype func,
+		      struct arc_instruction *insn);
+
+/* Get address of next instruction after INSN, assuming linear execution (no
+   taken branches).  If instruction has a delay slot, then returned value will
+   point at the instruction in delay slot.  That is - "address of instruction
+   + instruction length with LIMM".  */
+
+static inline bfd_vma
+arc_insn_get_linear_next_pc (const struct arc_instruction *insn)
+{
+  /* In ARC long immediate is always 4 bytes.  */
+  return (insn->address + insn->length + (insn->limm_p ? 4 : 0));
+}
+
+/* Get register with base address of memory operation.  */
+
+int arc_insn_get_memory_base_reg (const struct arc_instruction *insn);
+
+/* Get offset of a memory operation INSN.  */
+
+bfd_vma arc_insn_get_memory_offset (const struct arc_instruction *insn);
+
+/* Various functions that help with checking if given instruction has specified
+   [sub]opcode or that it is a particular type of instruction.  */
+
+static inline int
+arc_insn_match_op (const struct arc_instruction *insn, unsigned int opcode)
+{
+  return (insn->opcode == opcode);
+}
+
+static inline int
+arc_insn_match_subop1 (const struct arc_instruction *insn, unsigned int opcode,
+		       unsigned int subopcode1)
+{
+  return (insn->opcode == opcode && insn->subopcode1 == subopcode1);
+}
+
+static inline int
+arc_insn_match_subop2 (const struct arc_instruction *insn, unsigned int opcode,
+		       unsigned int subopcode1, unsigned int subopcode2)
+{
+  return (insn->opcode == opcode
+	  && insn->subopcode1 == subopcode1
+	  && insn->subopcode2 == subopcode2);
+}
+
+static inline int
+arc_insn_match_subop3 (const struct arc_instruction *insn, unsigned int opcode,
+		       unsigned int subopcode1, unsigned int subopcode2,
+		       unsigned int subopcode3)
+{
+  return (insn->opcode == opcode
+	  && insn->subopcode1 == subopcode1
+	  && insn->subopcode2 == subopcode2
+	  && insn->subopcode3 == subopcode3);
+}
+
+/* Provide insn_match shortcuts for commonly checked instructions.  There is an
+   alternative: use opcode_data->name to check for instruction, but using
+   opcodes looks preferably because it is possible that a new encoding can be
+   added for an existing instruction, so it will pass the "name" test, however
+   it might, for example, has a different set of operands, which will break
+   assumptions in current code about the operands.  If instructions are
+   detected by their opcodes, then it will be required to update those matching
+   instructions and all functions that use them.  */
+
+static inline int
+arc_insn_is_enter_s (const struct arc_instruction *insn)
+{
+  return arc_insn_match_subop2 (insn, 0x18, 0x7, 0x0);
+}
+
+static inline int
+arc_insn_is_leave_s (const struct arc_instruction *insn)
+{
+  return arc_insn_match_subop2 (insn, 0x18, 0x6, 0x0);
+}
+
+static inline int
+arc_insn_is_mov (const struct arc_instruction *insn)
+{
+  /* mov b,c  */
+  return (arc_insn_match_subop1 (insn, 0x04, 0xA)
+	  /* mov_s g,h  */
+	  || arc_insn_match_subop1 (insn, 0x08, 0x0)
+	  /* mov_s h,s3  */
+	  || arc_insn_match_subop1 (insn, 0x0E, 0x3)
+	  /* mov_s.ne b,h  */
+	  || arc_insn_match_subop1 (insn, 0x0E, 0x7)
+	  /* mov_s b,u8  */
+	  || arc_insn_match_op (insn, 0x1B));
+}
+
+static inline int
+arc_insn_is_pop_s (const struct arc_instruction *insn)
+{
+  return (arc_insn_match_subop2 (insn, 0x18, 0x6, 0x1)
+	  || arc_insn_match_subop2 (insn, 0x18, 0x6, 0x11));
+}
+
+static inline int
+arc_insn_is_push_s (const struct arc_instruction *insn)
+{
+  return (arc_insn_match_subop2 (insn, 0x18, 0x7, 0x1)
+	  || arc_insn_match_subop2 (insn, 0x18, 0x7, 0x11));
+}
+
+static inline int
+arc_insn_is_st (const struct arc_instruction *insn)
+{
+  /* st c,[b,s9]  */
+  return (arc_insn_match_op (insn, 0x03)
+	  /* st_s r0,[gp,s11]  */
+	  || arc_insn_match_subop1 (insn, 0x0A, 0x2)
+	  /* st_s c,[b,u7]  */
+	  || arc_insn_match_op (insn, 0x14)
+	  /* stb_s c,[b,u7]  */
+	  || arc_insn_match_op (insn, 0x15)
+	  /* sth_s c,[b,u7]  */
+	  || arc_insn_match_op (insn, 0x16)
+	  /* st_s b,[sp,u7]  */
+	  || arc_insn_match_subop1 (insn, 0x18, 0x2)
+	  /* stb_s b,[sp,u7]  */
+	  || arc_insn_match_subop1 (insn, 0x18, 0x3));
+}
+
+static inline int
+arc_insn_is_sub (const struct arc_instruction *insn)
+{
+  /* sub a,b,c  */
+  return (arc_insn_match_subop1 (insn, 0x4, 0x2)
+	  /* sub_s c,b,u3  */
+	  || arc_insn_match_subop1 (insn, 0x0D, 0x1)
+	  /* sub_s b,b,c  */
+	  || arc_insn_match_subop1 (insn, 0x0F, 0x2)
+	  /* sub_s.ne b,b,b  */
+	  || arc_insn_match_subop2 (insn, 0x0F, 0x0, 0x6)
+	  /* sub_s b,b,u5  */
+	  || arc_insn_match_subop1 (insn, 0x17, 0x3)
+	  /* sub_s sp,sp,u7  */
+	  || arc_insn_match_subop2 (insn, 0x18, 0x5, 0x1));
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
To do prologue analysis GDB needs to know a lot of information about
instructions, for example, instruction operands or whether instruction is a
predicated (which means that it is effectively a branch).  To provide GDB
necessary information this patch adds an API for instruction decoding.  It
consists of:
- arc_instruction structure that contains various information about instruction
- arc_insn_decode function that fills arc_instruction with data
- several functions specific to memory instructions that return address base
  register and offset information
- "match" functions that allow to check if arc_instruction matches particular
  opcode/subopcode and a few shortcuts for instructions commonly used in GDB.

To avoid too much code duplication arc_insn_decode uses arc_print_insn to
receive arc_opcode for the specified address.

```
opcodes/ChangeLog

yyyy-mm-dd  Anton Kolesov  <anton.kolesov@synopsys.com>

    * arc-dis.c (read_instruction): New function.
    (set_insn_subopcodes): Likewise.
    (set_insn_flags): Likewise.
    (set_insn_operands): Likewise.
    (arc_insn_decode): Likewise.
    (arc_insn_get_memory_base_reg): Likewise.
    (arc_insn_get_memory_offset): Likewise.
    (print_insn_arc): Pass arc_opcode to arc_insn_decode as private_data.
    * arc-dis.h (arc_ldst_writeback_mode): New enum.
    (arc_ldst_data_size): Likewise.
    (arc_condition_code): Likewise.
    (arc_operand_kind): Likewise.
    (arc_insn_kind): New struct.
    (arc_instruction): Likewise.
    (arc_insn_decode): New function.
    (arc_insn_get_linear_next_pc): Likewise.
    (arc_insn_get_memory_base_reg): Likewise.
    (arc_insn_get_memory_offset): Likewise.
    (arc_insn_match_op): Likewise.
    (arc_insn_match_subop1): Likewise.
    (arc_insn_match_subop2): Likewise.
    (arc_insn_match_subop3): Likewise.
    (arc_insn_is_enter_s): Likewise.
    (arc_insn_is_leave_s): Likewise.
    (arc_insn_is_mov): Likewise.
    (arc_insn_is_pop_s): Likewise.
    (arc_insn_is_push_s): Likewise.
    (arc_insn_is_st): Likewise.
    (arc_insn_is_sub): Likewise.
```
