### PR TITLE
Akolesov disasm options

### DIFF
--- a/bfd/cpu-arc.c
+++ b/bfd/cpu-arc.c
@@ -71,9 +71,6 @@ const bfd_arch_info_type bfd_arc_arch =
 static const bfd_arch_info_type *
 arc_compatible (const bfd_arch_info_type *a, const bfd_arch_info_type *b)
 {
-  const bfd_arch_info_type * const arc600 = &bfd_arc_arch;
-  const bfd_arch_info_type * const arc601 = &arch_info_struct[1];
-  const bfd_arch_info_type * const arc700 = &arch_info_struct[2];
   const bfd_arch_info_type * const em = &arch_info_struct[5];
   const bfd_arch_info_type * const hs = &arch_info_struct[6];
 
@@ -89,10 +86,6 @@ arc_compatible (const bfd_arch_info_type *a, const bfd_arch_info_type *b)
   if (a->bits_per_word != b->bits_per_word)
     return NULL;
 
-  /* HS and EM are not compatible.  */
-  if ((a == em && b == hs) || (a == hs && b == em))
-    return NULL;
-
   /* ARCv2|EM and EM.  */
   if ((a->mach == bfd_mach_arc_arcv2 && b == em)
       || (b->mach == bfd_mach_arc_arcv2 && a == em))
@@ -103,24 +96,5 @@ arc_compatible (const bfd_arch_info_type *a, const bfd_arch_info_type *b)
       || (b->mach == bfd_mach_arc_arcv2 && a == hs))
     return hs;
 
-  /* ARC700.  */
-  if (a->mach == bfd_mach_arc_arc700 && b->mach == bfd_mach_arc_arc700)
-    return arc700;
-
-  /* ARC600.  */
-  if (a->mach == bfd_mach_arc_arc600 && b->mach == bfd_mach_arc_arc600)
-    return arc600;
-
-  /* ARC601.  */
-  if (a->mach == bfd_mach_arc_arc601 && b->mach == bfd_mach_arc_arc601)
-    return arc601;
-
-  /* A4 and A5 are not present in arch_info_struct, so always return A.  */
-  if (a->mach == bfd_mach_arc_a4 && b->mach == bfd_mach_arc_a4)
-    return a;
-
-  if (a->mach == bfd_mach_arc_a5 && b->mach == bfd_mach_arc_a5)
-    return a;
-
-  return NULL;
+  return bfd_default_compatible (a, b);
 }

--- a/bfd/cpu-arc.c
+++ b/bfd/cpu-arc.c
@@ -42,13 +42,12 @@
 
 static const bfd_arch_info_type arch_info_struct[] =
 {
-  ARC (bfd_mach_arc_arc600, "ARC600", FALSE, &arch_info_struct[1]),
-  ARC (bfd_mach_arc_arc600, "A6"    , FALSE, &arch_info_struct[2]),
-  ARC (bfd_mach_arc_arc601, "ARC601", FALSE, &arch_info_struct[3]),
-  ARC (bfd_mach_arc_arc700, "ARC700", FALSE, &arch_info_struct[4]),
-  ARC (bfd_mach_arc_arc700, "A7",     FALSE, &arch_info_struct[5]),
-  ARC (bfd_mach_arc_arcv2,  "ARCv2",  FALSE, &arch_info_struct[6]),
-  ARC (bfd_mach_arc_arcv2,  "EM",     FALSE, &arch_info_struct[7]),
+  ARC (bfd_mach_arc_arc600, "A6"    , FALSE, &arch_info_struct[1]),
+  ARC (bfd_mach_arc_arc601, "ARC601", FALSE, &arch_info_struct[2]),
+  ARC (bfd_mach_arc_arc700, "ARC700", FALSE, &arch_info_struct[3]),
+  ARC (bfd_mach_arc_arc700, "A7",     FALSE, &arch_info_struct[4]),
+  ARC (bfd_mach_arc_arcv2,  "ARCv2",  FALSE, &arch_info_struct[5]),
+  ARC (bfd_mach_arc_arcv2,  "EM",     FALSE, &arch_info_struct[6]),
   ARC (bfd_mach_arc_arcv2,  "HS",     FALSE, NULL),
 };
 

--- a/bfd/cpu-arc.c
+++ b/bfd/cpu-arc.c
@@ -23,6 +23,9 @@
 #include "bfd.h"
 #include "libbfd.h"
 
+static const bfd_arch_info_type *
+arc_compatible (const bfd_arch_info_type *a, const bfd_arch_info_type *b);
+
 #define ARC(mach, print_name, default_p, next) \
 {					\
     32,	/* 32 bits in a word  */	\
@@ -34,7 +37,7 @@
     print_name,				\
     4, /* section alignment power  */	\
     default_p,				\
-    bfd_default_compatible,		\
+    arc_compatible,			\
     bfd_default_scan,			\
     bfd_arch_default_fill,		\
     next,				\
@@ -53,3 +56,71 @@ static const bfd_arch_info_type arch_info_struct[] =
 
 const bfd_arch_info_type bfd_arc_arch =
   ARC (bfd_mach_arc_arc600, "ARC600", TRUE, &arch_info_struct[0]);
+
+/* ARC-specific "compatible" function.  The general rule is that if A and B are
+   compatible, then this function should return architecture that is more
+   "feature-rich", that is, can run both A and B.  ARCv2, EM and HS all has
+   same mach number, so bfd_default_compatible assumes they are the same, and
+   returns an A.  That causes issues with GDB, because GDB assumes that if
+   machines are compatible, then "compatible ()" always returns same machine
+   regardless of argument order.  As a result GDB gets confused because, for
+   example, compatible (ARCv2, EM) returns ARCv2, but compatible (EM, ARCv2)
+   returns EM, hence GDB is not sure if they are compatible and prints a
+   warning.  */
+
+static const bfd_arch_info_type *
+arc_compatible (const bfd_arch_info_type *a, const bfd_arch_info_type *b)
+{
+  const bfd_arch_info_type * const arc600 = &bfd_arc_arch;
+  const bfd_arch_info_type * const arc601 = &arch_info_struct[1];
+  const bfd_arch_info_type * const arc700 = &arch_info_struct[2];
+  const bfd_arch_info_type * const em = &arch_info_struct[5];
+  const bfd_arch_info_type * const hs = &arch_info_struct[6];
+
+  /* Trivial case where a and b is the same instance.  Some callers already
+     check this condition but some do not and get an invalid result.  */
+  if (a == b)
+    return a;
+
+  /* If a & b are for different architecture we can do nothing.  */
+  if (a->arch != b->arch)
+    return NULL;
+
+  if (a->bits_per_word != b->bits_per_word)
+    return NULL;
+
+  /* HS and EM are not compatible.  */
+  if ((a == em && b == hs) || (a == hs && b == em))
+    return NULL;
+
+  /* ARCv2|EM and EM.  */
+  if ((a->mach == bfd_mach_arc_arcv2 && b == em)
+      || (b->mach == bfd_mach_arc_arcv2 && a == em))
+    return em;
+
+  /* ARCv2|HS and HS.  */
+  if ((a->mach == bfd_mach_arc_arcv2 && b == hs)
+      || (b->mach == bfd_mach_arc_arcv2 && a == hs))
+    return hs;
+
+  /* ARC700.  */
+  if (a->mach == bfd_mach_arc_arc700 && b->mach == bfd_mach_arc_arc700)
+    return arc700;
+
+  /* ARC600.  */
+  if (a->mach == bfd_mach_arc_arc600 && b->mach == bfd_mach_arc_arc600)
+    return arc600;
+
+  /* ARC601.  */
+  if (a->mach == bfd_mach_arc_arc601 && b->mach == bfd_mach_arc_arc601)
+    return arc601;
+
+  /* A4 and A5 are not present in arch_info_struct, so always return A.  */
+  if (a->mach == bfd_mach_arc_a4 && b->mach == bfd_mach_arc_a4)
+    return a;
+
+  if (a->mach == bfd_mach_arc_a5 && b->mach == bfd_mach_arc_a5)
+    return a;
+
+  return NULL;
+}

--- a/binutils/doc/binutils.texi
+++ b/binutils/doc/binutils.texi
@@ -2306,6 +2306,14 @@ printed in hexadecimal using @option{hex}.  By default, the short
 immediates are printed using the decimal representation, while the
 long immediate values are printed as hexadecimal.
 
+@option{cpu=...} allows to enforce a particular ISA when disassembling
+instructions, overriding the @option{-m} value or whatever is in the ELF file.
+This might be useful to select ARC EM or HS ISA, because architecture is same
+for those and disassembler relies on private ELF header data to decide if code
+is for EM or HS.  This option might be specified multiple times - only the
+latest value will be used.  Valid values are same as for the assembler
+@option{-mcpu=...} option.
+
 If the target is an ARM architecture then this switch can be used to
 select which register name set is used during disassembler.  Specifying
 @option{-M reg-names-std} (the default) will select the register names as

--- a/gas/config/tc-arc.c
+++ b/gas/config/tc-arc.c
@@ -445,6 +445,8 @@ static struct hash_control *arc_addrtype_hash;
 #define ARC_CPU_TYPE_AV2HS(NAME,EXTRA)			\
   { #NAME,  ARC_OPCODE_ARCv2HS, bfd_mach_arc_arcv2,	\
       EF_ARC_CPU_ARCV2HS, EXTRA}
+#define ARC_CPU_TYPE_NONE				\
+  { 0, 0, 0, 0, 0 }
 
 /* A table of CPU names and opcode sets.  */
 static const struct cpu_type
@@ -457,32 +459,7 @@ static const struct cpu_type
 }
   cpu_types[] =
 {
-  ARC_CPU_TYPE_A7xx (arc700, 0x00),
-  ARC_CPU_TYPE_A7xx (nps400, NPS400),
-
-  ARC_CPU_TYPE_AV2EM (arcem,	  0x00),
-  ARC_CPU_TYPE_AV2EM (em,	  0x00),
-  ARC_CPU_TYPE_AV2EM (em4,	  CD),
-  ARC_CPU_TYPE_AV2EM (em4_dmips,  CD),
-  ARC_CPU_TYPE_AV2EM (em4_fpus,	  CD),
-  ARC_CPU_TYPE_AV2EM (em4_fpuda,  CD | DPA),
-  ARC_CPU_TYPE_AV2EM (quarkse_em, CD | SPX | DPX),
-
-  ARC_CPU_TYPE_AV2HS (archs,	  CD),
-  ARC_CPU_TYPE_AV2HS (hs,	  CD),
-  ARC_CPU_TYPE_AV2HS (hs34,	  CD),
-  ARC_CPU_TYPE_AV2HS (hs38,	  CD),
-  ARC_CPU_TYPE_AV2HS (hs38_linux, CD),
-
-  ARC_CPU_TYPE_A6xx (arc600, 0x00),
-  ARC_CPU_TYPE_A6xx (arc600_norm,     0x00),
-  ARC_CPU_TYPE_A6xx (arc600_mul64,    0x00),
-  ARC_CPU_TYPE_A6xx (arc600_mul32x16, 0x00),
-  ARC_CPU_TYPE_A6xx (arc601,	      0x00),
-  ARC_CPU_TYPE_A6xx (arc601_norm,     0x00),
-  ARC_CPU_TYPE_A6xx (arc601_mul64,    0x00),
-  ARC_CPU_TYPE_A6xx (arc601_mul32x16, 0x00),
-  { 0, 0, 0, 0, 0 }
+  #include "elf/arc-cpu.def"
 };
 
 /* Information about the cpu/variant we're assembling for.  */

--- a/include/elf/arc-cpu.def
+++ b/include/elf/arc-cpu.def
@@ -1,0 +1,49 @@
+/* ARC processor types
+   Copyright (C) 2017 Free Software Foundation, Inc.
+
+   This file is part of GAS, the GNU Assembler.
+
+   GAS is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GAS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GAS; see the file COPYING.  If not, write to the Free
+   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
+   02110-1301, USA.  */
+
+
+ARC_CPU_TYPE_A7xx (arc700, 0x00),
+ARC_CPU_TYPE_A7xx (nps400, NPS400),
+
+ARC_CPU_TYPE_AV2EM (arcem,	0x00),
+ARC_CPU_TYPE_AV2EM (em,		0x00),
+ARC_CPU_TYPE_AV2EM (em4,	CD),
+ARC_CPU_TYPE_AV2EM (em4_dmips,  CD),
+ARC_CPU_TYPE_AV2EM (em4_fpus,	CD),
+ARC_CPU_TYPE_AV2EM (em4_fpuda,  CD | DPA),
+ARC_CPU_TYPE_AV2EM (quarkse_em, CD | SPX | DPX),
+
+ARC_CPU_TYPE_AV2HS (archs,	CD),
+ARC_CPU_TYPE_AV2HS (hs,		CD),
+ARC_CPU_TYPE_AV2HS (hs34,	CD),
+ARC_CPU_TYPE_AV2HS (hs38,	CD),
+ARC_CPU_TYPE_AV2HS (hs38_linux, CD),
+
+ARC_CPU_TYPE_A6xx (arc600, 0x00),
+ARC_CPU_TYPE_A6xx (arc600_norm,     0x00),
+ARC_CPU_TYPE_A6xx (arc600_mul64,    0x00),
+ARC_CPU_TYPE_A6xx (arc600_mul32x16, 0x00),
+ARC_CPU_TYPE_A6xx (arc601,	    0x00),
+ARC_CPU_TYPE_A6xx (arc601_norm,     0x00),
+ARC_CPU_TYPE_A6xx (arc601_mul64,    0x00),
+ARC_CPU_TYPE_A6xx (arc601_mul32x16, 0x00),
+
+ARC_CPU_TYPE_NONE
+

--- a/opcodes/arc-dis.c
+++ b/opcodes/arc-dis.c
@@ -120,6 +120,11 @@ static linkclass decodelist = NULL;
 /* True if we want to print using only hex numbers.  */
 static bfd_boolean print_hex = FALSE;
 
+/* ISA mask value enforced via disassembler info options.  ARC_OPCODE_NONE
+   value means that no CPU is enforced.  */
+
+static unsigned enforced_isa_mask = ARC_OPCODE_NONE;
+
 /* Macros section.  */
 
 #ifdef DEBUG
@@ -785,6 +790,49 @@ parse_option (char *option)
     fprintf (stderr, _("Unrecognised disassembler option: %s\n"), option);
 }
 
+#define ARC_CPU_TYPE_A6xx(NAME,EXTRA)			\
+  { #NAME, ARC_OPCODE_ARC600, "ARC600" }
+#define ARC_CPU_TYPE_A7xx(NAME,EXTRA)			\
+  { #NAME, ARC_OPCODE_ARC700, "ARC700" }
+#define ARC_CPU_TYPE_AV2EM(NAME,EXTRA)			\
+  { #NAME,  ARC_OPCODE_ARCv2EM, "ARC EM" }
+#define ARC_CPU_TYPE_AV2HS(NAME,EXTRA)			\
+  { #NAME,  ARC_OPCODE_ARCv2HS, "ARC HS" }
+#define ARC_CPU_TYPE_NONE				\
+  { 0, 0, 0 }
+
+/* A table of CPU names and opcode sets.  */
+static const struct cpu_type
+{
+  const char *name;
+  unsigned flags;
+  const char *isa;
+}
+  cpu_types[] =
+{
+  #include "elf/arc-cpu.def"
+};
+
+/* Helper for parsing the CPU options.  Accept any of the ARC architectures
+   values.  OPTION should be a value passed to cpu=.  */
+
+static unsigned
+parse_cpu_option (const char *option)
+{
+  int i;
+
+  for (i = 0; cpu_types[i].name; ++i)
+    {
+      if (!strcasecmp (cpu_types[i].name, option))
+	{
+	  return cpu_types[i].flags;
+	}
+    }
+
+  fprintf (stderr, _("Unrecognised disassembler CPU option: %s\n"), option);
+  return ARC_OPCODE_NONE;
+}
+
 /* Go over the options list and parse it.  */
 
 static void
@@ -792,6 +840,12 @@ parse_disassembler_options (char *options)
 {
   if (options == NULL)
     return;
+
+  /* Disassembler might be reused for difference CPU's, and cpu option set for
+     the first one shouldn't be applied to second (which might not have
+     explicit cpu in its options.  Therefore it is required to reset enforced
+     CPU when new options are being parsed.  */
+  enforced_isa_mask = ARC_OPCODE_NONE;
 
   while (*options)
     {
@@ -802,7 +856,13 @@ parse_disassembler_options (char *options)
 	  continue;
 	}
 
-      parse_option (options);
+      /* A CPU option?  Cannot use STRING_COMMA_LEN because strncmp is also a
+	 preprocessor macro.  */
+      if (strncmp (options, "cpu=", 4) == 0)
+	/* Strip leading `cpu=`.  */
+	enforced_isa_mask = parse_cpu_option (options + 4);
+      else
+	parse_option (options);
 
       while (*options != ',' && *options != '\0')
 	++ options;
@@ -874,7 +934,7 @@ print_insn_arc (bfd_vma memaddr,
   int status;
   unsigned int insn_len;
   unsigned long long insn = 0;
-  unsigned isa_mask;
+  unsigned isa_mask = ARC_OPCODE_NONE;
   const struct arc_opcode *opcode;
   bfd_boolean need_comma;
   bfd_boolean open_braket;
@@ -882,7 +942,6 @@ print_insn_arc (bfd_vma memaddr,
   const struct arc_operand *operand;
   int value;
   struct arc_operand_iterator iter;
-  Elf_Internal_Ehdr *header = NULL;
   struct arc_disassemble_info *arc_infop;
 
   if (info->disassembler_options)
@@ -900,34 +959,44 @@ print_insn_arc (bfd_vma memaddr,
   highbyte  = ((info->endian == BFD_ENDIAN_LITTLE) ? 1 : 0);
   lowbyte = ((info->endian == BFD_ENDIAN_LITTLE) ? 0 : 1);
 
-  if (info->section && info->section->owner)
-    header = elf_elfheader (info->section->owner);
-
-  switch (info->mach)
+  /* Figure out CPU type, unless it was enforced via disassembler options.  */
+  if (enforced_isa_mask == ARC_OPCODE_NONE)
     {
-    case bfd_mach_arc_arc700:
-      isa_mask = ARC_OPCODE_ARC700;
-      break;
+      Elf_Internal_Ehdr *header = NULL;
 
-    case bfd_mach_arc_arc600:
-      isa_mask = ARC_OPCODE_ARC600;
-      break;
+      if (info->section && info->section->owner)
+	header = elf_elfheader (info->section->owner);
 
-    case bfd_mach_arc_arcv2:
-    default:
-      isa_mask = ARC_OPCODE_ARCv2EM;
-      /* TODO: Perhaps remove defitinion of header since it is only used at
-	 this location.  */
-      if (header != NULL
-	  && (header->e_flags & EF_ARC_MACH_MSK) == EF_ARC_CPU_ARCV2HS)
+      switch (info->mach)
 	{
-	  isa_mask = ARC_OPCODE_ARCv2HS;
-	  /* FPU instructions are not extensions for HS.  */
-	  add_to_decodelist (FLOAT, SP);
-	  add_to_decodelist (FLOAT, DP);
-	  add_to_decodelist (FLOAT, CVT);
+	case bfd_mach_arc_arc700:
+	  isa_mask = ARC_OPCODE_ARC700;
+	  break;
+
+	case bfd_mach_arc_arc600:
+	  isa_mask = ARC_OPCODE_ARC600;
+	  break;
+
+	case bfd_mach_arc_arcv2:
+	default:
+	  isa_mask = ARC_OPCODE_ARCv2EM;
+	  /* TODO: Perhaps remove definition of header since it is only used at
+	     this location.  */
+	  if (header != NULL
+	      && (header->e_flags & EF_ARC_MACH_MSK) == EF_ARC_CPU_ARCV2HS)
+	    isa_mask = ARC_OPCODE_ARCv2HS;
+	  break;
 	}
-      break;
+    }
+  else
+    isa_mask = enforced_isa_mask;
+
+  if (isa_mask == ARC_OPCODE_ARCv2HS)
+    {
+      /* FPU instructions are not extensions for HS.  */
+      add_to_decodelist (FLOAT, SP);
+      add_to_decodelist (FLOAT, DP);
+      add_to_decodelist (FLOAT, CVT);
     }
 
   /* This variable may be set by the instruction decoder.  It suggests
@@ -1298,9 +1367,19 @@ arc_get_disassembler (bfd *abfd)
 void
 print_arc_disassembler_options (FILE *stream)
 {
+  int i;
+
   fprintf (stream, _("\n\
 The following ARC specific disassembler options are supported for use \n\
 with -M switch (multiple options should be separated by commas):\n"));
+
+  /* cpu=... options.  */
+  for (i = 0; cpu_types[i].name; ++i)
+    {
+      /* As of now all value CPU values are less than 16 characters.  */
+      fprintf (stream, "  cpu=%-16s\tEnforce %s ISA.\n",
+	       cpu_types[i].name, cpu_types[i].isa);
+    }
 
   fprintf (stream, _("\
   dsp             Recognize DSP instructions.\n"));


### PR DESCRIPTION
 Proposition of changes that will allow GDB to select current CPU in disassembler.

1. First patch adds support for `cpu=...` disassembler option that allows to override CPU from mach/private ELF header.
2. Second patch removes duplicate ARC600 entry
3. Third part provides custom bfd_arch_compatible function to satisfy GDB expectations of what it should return for ARC variants.