### PR TITLE
Fix potential copy-paste issue for VMA.

### DIFF
--- a/bfd/arc-got.h
+++ b/bfd/arc-got.h
@@ -341,7 +341,7 @@ relocate_fix_got_relocs_for_got_info (struct got_entry **          list_p,
 			    "GOT_TLS_IE"),
 			   (long) (sym_value - sec_vma),
 			   (long) (htab->sgot->output_section->vma
-			      + htab->sgot->output_offset->vma
+			      + htab->sgot->output_offset
 			      + entry->offset
 			      + (entry->existing_entries == TLS_GOT_MOD_AND_OFF
 				 ? 4 : 0)),
@@ -368,7 +368,7 @@ relocate_fix_got_relocs_for_got_info (struct got_entry **          list_p,
 			    "GOT_TLS_IE"),
 			   (long) (sym_value - sec_vma),
 			   (long) (htab->sgot->output_section->vma
-			      + htab->sgot->output_offset->vma
+			      + htab->sgot->output_offset
 			      + entry->offset
 			      + (entry->existing_entries == TLS_GOT_MOD_AND_OFF
 				 ? 4 : 0)),

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -1214,7 +1214,7 @@ arc_special_overflow_checks (const struct arc_relocation_data reloc_data,
       else								\
 	ARC_DEBUG ("symbol_section->vma = NULL\n");			\
       if (input_section->output_section != NULL)			\
-	ARC_DEBUG ("symbol_section->vma = %#lx\n",			\
+	ARC_DEBUG ("input_section->output_section->vma = %#lx\n",       \
 		   input_section->output_section->vma			\
 		   + input_section->output_offset);			\
       else								\


### PR DESCRIPTION
Hi ARC GNU toolchain developers,

Enabled ARC_ENABLE_DEBUG `#define ARC_ENABLE_DEBUG 1`  for debugging `reloc_data.input_section->output_section->vma` to [compare with LLD](http://lists.llvm.org/pipermail/llvm-dev/2017-September/117568.html).

But failed to compile binutils owing to `bfd/arc-got.h` [line 344](https://github.com/foss-for-synopsys-dwc-arc-processors/binutils-gdb/blob/arc-2017.09/bfd/arc-got.h#L344) and [371](https://github.com/foss-for-synopsys-dwc-arc-processors/binutils-gdb/blob/arc-2017.09/bfd/arc-got.h#L371).

So I simply fixed the issue, please review it, thanks a lot!

Regards,
Leslie Zhai