### PR TITLE
Fix gdb build with gcc 4.5.0

### DIFF
--- a/gdb/breakpoint.c
+++ b/gdb/breakpoint.c
@@ -3171,10 +3171,10 @@ static const char *const longjmp_names[] =
 struct breakpoint_objfile_data
 {
   /* Minimal symbol for "_ovly_debug_event" (if any).  */
-  struct bound_minimal_symbol overlay_msym {};
+  struct bound_minimal_symbol overlay_msym;
 
   /* Minimal symbol(s) for "longjmp", "siglongjmp", etc. (if any).  */
-  struct bound_minimal_symbol longjmp_msym[NUM_LONGJMP_NAMES] {};
+  struct bound_minimal_symbol longjmp_msym[NUM_LONGJMP_NAMES];
 
   /* True if we have looked for longjmp probes.  */
   int longjmp_searched = 0;
@@ -3184,10 +3184,10 @@ struct breakpoint_objfile_data
   std::vector<probe *> longjmp_probes;
 
   /* Minimal symbol for "std::terminate()" (if any).  */
-  struct bound_minimal_symbol terminate_msym {};
+  struct bound_minimal_symbol terminate_msym;
 
   /* Minimal symbol for "_Unwind_DebugHook" (if any).  */
-  struct bound_minimal_symbol exception_msym {};
+  struct bound_minimal_symbol exception_msym;
 
   /* True if we have looked for exception probes.  */
   int exception_searched = 0;

--- a/gdb/hppa-tdep.c
+++ b/gdb/hppa-tdep.c
@@ -2531,7 +2531,7 @@ struct bound_minimal_symbol
 hppa_lookup_stub_minimal_symbol (const char *name,
 				 enum unwind_stub_types stub_type)
 {
-  struct bound_minimal_symbol result = { NULL, NULL };
+  struct bound_minimal_symbol result;
 
   for (objfile *objfile : current_program_space->objfiles ())
     {

--- a/gdb/linespec.c
+++ b/gdb/linespec.c
@@ -4273,8 +4273,7 @@ add_minsym (struct minimal_symbol *minsym, struct objfile *objfile,
   if (!list_mode && !msymbol_is_function (objfile, minsym))
     return;
 
-  struct bound_minimal_symbol mo = {minsym, objfile};
-  msyms->push_back (mo);
+  msyms->emplace_back (minsym, objfile);
   return;
 }
 

--- a/gdb/minsyms.c
+++ b/gdb/minsyms.c
@@ -230,13 +230,13 @@ add_minsym_to_demangled_hash_table (struct minimal_symbol *sym,
 struct found_minimal_symbols
 {
   /* External symbols are best.  */
-  bound_minimal_symbol external_symbol {};
+  bound_minimal_symbol external_symbol;
 
   /* File-local symbols are next best.  */
-  bound_minimal_symbol file_symbol {};
+  bound_minimal_symbol file_symbol;
 
   /* Symbols for shared library trampolines are next best.  */
-  bound_minimal_symbol trampoline_symbol {};
+  bound_minimal_symbol trampoline_symbol;
 
   /* Called when a symbol name matches.  Check if the minsym is a
      better type than what we had already found, and record it in one
@@ -601,8 +601,8 @@ struct bound_minimal_symbol
 lookup_minimal_symbol_text (const char *name, struct objfile *objf)
 {
   struct minimal_symbol *msymbol;
-  struct bound_minimal_symbol found_symbol = { NULL, NULL };
-  struct bound_minimal_symbol found_file_symbol = { NULL, NULL };
+  struct bound_minimal_symbol found_symbol;
+  struct bound_minimal_symbol found_file_symbol;
 
   unsigned int hash = msymbol_hash (name) % MINIMAL_SYMBOL_HASH_SIZE;
 

--- a/gdb/minsyms.h
+++ b/gdb/minsyms.h
@@ -28,6 +28,14 @@ struct type;
 
 struct bound_minimal_symbol
 {
+  bound_minimal_symbol (struct minimal_symbol *msym, struct objfile *objf)
+    : minsym (msym),
+      objfile (objf)
+  {
+  }
+
+  bound_minimal_symbol () = default;
+
   /* The minimal symbol that was found, or NULL if no minimal symbol
      was found.  */
 

--- a/gdb/psymtab.c
+++ b/gdb/psymtab.c
@@ -1577,7 +1577,7 @@ maintenance_print_psymbols (const char *args, int from_tty)
 
 	  if (address_arg != NULL)
 	    {
-	      struct bound_minimal_symbol msymbol = { NULL, NULL };
+	      struct bound_minimal_symbol msymbol;
 
 	      /* We don't assume each pc has a unique objfile (this is for
 		 debugging).  */


### PR DESCRIPTION
This patch fixes following error with old gcc compiler:
```
13:06:09  [EXTRA]    Building cross gdb
13:07:18  [ERROR]    /SCRATCH/arcjenkins2/slaves/us01-custom-arcgnu2/workspace/arcoss_verification/sandbox_sg/ARC-GNU-toolchain-verification/build_toolchain-3/crosstool-ng/.build/arc64-snps-linux-gnu/src/gdb/gdb/linespec.c:4276:52: error: could not convert '{minsym, objfile}' from '<brace-enclosed initializer list>' to 'bound_minimal_symbol'
13:07:18  [ERROR]    make[3]: *** [Makefile:1660: linespec.o] Error 1
13:07:18  [ERROR]    make[3]: *** Waiting for unfinished jobs....
13:07:20  [ERROR]    make[2]: *** [Makefile:11723: all-gdb] Error 2
13:07:20  [ERROR]    make[1]: *** [Makefile:1000: all] Error 2
```