### PR TITLE
Bruno relocation fixes

### DIFF
--- a/include/elf/arc-reloc.def
+++ b/include/elf/arc-reloc.def
@@ -208,7 +208,7 @@ ARC_RELOC_HOWTO(ARC_32_ME, 27, \
                 4, \
                 32, \
                 replace_limm, \
-                signed, \
+                bitfield, \
                 ( ME ( ( S + A ) ) ))
 
 ARC_RELOC_HOWTO(ARC_32_ME_S, 105, \
@@ -376,21 +376,21 @@ ARC_RELOC_HOWTO(ARC_GLOB_DAT, 54, \
                 4, \
                 32, \
                 replace_word32, \
-                signed, \
+                bitfield, \
                 S)
 
 ARC_RELOC_HOWTO(ARC_JMP_SLOT, 55, \
                 4, \
                 32, \
                 replace_word32, \
-                signed, \
+                bitfield, \
                 ( ME ( S ) ))
 
 ARC_RELOC_HOWTO(ARC_RELATIVE, 56, \
                 4, \
                 32, \
                 replace_word32, \
-                signed, \
+                bitfield, \
                 ( ME ( ( B + A ) ) ))
 
 ARC_RELOC_HOWTO(ARC_GOTOFF, 57, \

--- a/include/elf/arc-reloc.def
+++ b/include/elf/arc-reloc.def
@@ -211,13 +211,6 @@ ARC_RELOC_HOWTO(ARC_32_ME, 27, \
                 bitfield, \
                 ( ME ( ( S + A ) ) ))
 
-ARC_RELOC_HOWTO(ARC_32_ME_S, 105, \
-                4, \
-                32, \
-                replace_limms, \
-                signed, \
-                ( ME ( ( S + A ) ) ))
-
 ARC_RELOC_HOWTO(ARC_N32_ME, 28, \
                 4, \
                 32, \


### PR DESCRIPTION
Fixes for https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/565 and https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/564.

Removed ARC_32_ME_S encoding and updated the following fields


Enum | Hex | ELF Reloc Type | Type | Details
-- | -- | -- | -- | --
27 | 0x1b | R_ARC_32_ME | signed -> bitfiled | word32 = ME (S + A)
54 | 0x36 | R_ARC_GLOB_DAT | signed -> bitfiled | word32= S
55 | 0x37 | R_ARC_JMP_SLOT | signed -> bitfiled | word32 = ME(S)
56 | 0x38 | R_ARC_RELATIVE | signed -> bitfiled | word32 = ME(B+A)

