### PR TITLE
ldfile: Fix missing validation.

### DIFF
--- a/ld/ldfile.c
+++ b/ld/ldfile.c
@@ -353,7 +353,9 @@ ldfile_try_open_bfd (const char *attempt,
     }
 
   /* PR 30568: Do not track lto generated temporary object files.  */
+#if BFD_SUPPORTS_PLUGINS
   if (!entry->flags.lto_output)
+#endif
     track_dependency_files (attempt);
 
   /* Linker needs to decompress sections.  */


### PR DESCRIPTION
When using `--disable-plugins`, `lto_output` is non existent in the `struct lang_input_statement_flags` and with that, a proper validation has been added.

This problem was raised by issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/589