### PR TITLE
Don't use multiline in arc-disassembler-options.exp test

### DIFF
--- a/gdb/testsuite/gdb.arch/arc-disassembler-options.exp
+++ b/gdb/testsuite/gdb.arch/arc-disassembler-options.exp
@@ -28,10 +28,10 @@ if { [gdb_compile "${srcdir}/${subdir}/${srcfile}" "${objfile}" object {}] \
 clean_restart ${objfile}
 
 proc arc_disassemble_test { func insn mesg } {
-    gdb_test "disassemble $func" \
-	"Dump of assembler code for function $func:\r\n\
-	\[^:\]+:\t$insn\r\nEnd of assembler dump\." \
-	$mesg
+    set prologue "Dump of assembler code for function $func:\r\n"
+    set content "\[^:\]+:\t$insn\r\n"
+    set epilogue "End of assembler dump\."
+    gdb_test "disassemble $func" "$prologue$content$epilogue" $mesg
 }
 
 # Verify defaults.


### PR DESCRIPTION
Breaking a TCL string to several lines leads to adding of extra symbols to the resuling expect string. In turn, this leads to failing of all test cases in gdb.arch/arc-disassembler-options.exp testsuite.