### PR TITLE
Add native GDB port for HS5x and a couple of fixes

### DIFF
--- a/gdb/arc-tdep.c
+++ b/gdb/arc-tdep.c
@@ -295,7 +295,8 @@ static const struct arc_register_feature arc_common_aux_reg_feature =
     { ARC_FIRST_AUX_REGNUM + 1, { "status32" }, true },
     { ARC_FIRST_AUX_REGNUM + 2, { "lp_start" }, false },
     { ARC_FIRST_AUX_REGNUM + 3, { "lp_end" }, false },
-    { ARC_FIRST_AUX_REGNUM + 4, { "bta" }, false }
+    { ARC_FIRST_AUX_REGNUM + 4, { "bta" }, false },
+    { ARC_FIRST_AUX_REGNUM + 5, { "eret" }, false }
   }
 };
 

--- a/gdb/arc64-linux-nat.c
+++ b/gdb/arc64-linux-nat.c
@@ -1,0 +1,271 @@
+/* Native-dependent code for GNU/Linux ARC.
+
+   Copyright 2024 Free Software Foundation, Inc.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include "frame.h"
+#include "inferior.h"
+#include "gdbcore.h"
+#include "regcache.h"
+#include "gdbsupport/gdb_assert.h"
+#include "target.h"
+#include "linux-nat.h"
+#include "nat/gdb_ptrace.h"
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <signal.h>
+#include <sys/user.h>
+#include <sys/ioctl.h>
+#include "gdbsupport/gdb_wait.h"
+#include <fcntl.h>
+#include <sys/procfs.h>
+#include <linux/elf.h>
+
+#include "gregset.h"
+#include "arc64-tdep.h"
+#include "arc64-linux-tdep.h"
+#include "arch/arc.h"
+
+/* Defines ps_err_e, struct ps_prochandle.  */
+#include "gdb_proc_service.h"
+
+/* Print an "arc-linux-nat" debug statement.  */
+
+#define arc_linux_nat_debug_printf(fmt, ...) \
+  debug_prefixed_printf_cond (arc_debug, "arc-linux-nat", fmt, ##__VA_ARGS__)
+
+class arc_linux_nat_target final : public linux_nat_target
+{
+public:
+  /* Add ARC register access methods.  */
+  void fetch_registers (struct regcache *, int) override;
+  void store_registers (struct regcache *, int) override;
+
+  const struct target_desc *read_description () override;
+
+  /* Handle threads  */
+  void low_prepare_to_resume (struct lwp_info *lp) override;
+};
+
+static arc_linux_nat_target the_arc_linux_nat_target;
+
+/* Read general registers from target process/thread (via ptrace)
+   into REGCACHE.  */
+
+static void
+fetch_gregs (struct regcache *regcache, int regnum)
+{
+  const int tid = get_ptrace_pid (regcache->ptid ());
+  struct gdbarch *gdbarch = regcache->arch ();
+  const struct regset *regset;
+  struct iovec iov;
+  gdb_gregset_t regs;
+
+  if (arc64_isa_reg_size (gdbarch) == 4)
+    regset = &arc32_linux_gregset;
+  else
+    perror_with_name (_("ARCv3 64-bit is not supported yet"));
+
+  iov.iov_base = &regs;
+  iov.iov_len = sizeof (gdb_gregset_t);
+
+  if (ptrace (PTRACE_GETREGSET, tid, NT_PRSTATUS, (void *) &iov) < 0)
+    perror_with_name (_("Couldn't get general registers"));
+  else
+    arc_linux_supply_gregset (regset, regcache, regnum, &regs, 0);
+}
+
+/* Store general registers from REGCACHE into the target process/thread.  */
+
+static void
+store_gregs (const struct regcache *regcache, int regnum)
+{
+  const int tid = get_ptrace_pid (regcache->ptid ());
+  struct gdbarch *gdbarch = regcache->arch ();
+  const struct regset *regset;
+  struct iovec iov;
+  gdb_gregset_t regs;
+
+  if (arc64_isa_reg_size (gdbarch) == 4)
+    regset = &arc32_linux_gregset;
+  else
+    perror_with_name (_("ARCv3 64-bit is not supported yet"));
+
+  iov.iov_base = &regs;
+  iov.iov_len = sizeof (gdb_gregset_t);
+
+  if (ptrace (PTRACE_GETREGSET, tid, NT_PRSTATUS, (void *) &iov) < 0)
+    perror_with_name (_("Couldn't get general registers"));
+  else
+    {
+      arc_linux_collect_gregset (regset, regcache, regnum, regs, 0);
+
+      if (ptrace (PTRACE_SETREGSET, tid, NT_PRSTATUS, (void *) &iov) < 0)
+	perror_with_name (_("Couldn't write general registers"));
+    }
+}
+
+/* Target operation: Read REGNUM register (all registers if REGNUM == -1)
+   from target process into REGCACHE.  */
+
+void
+arc_linux_nat_target::fetch_registers (struct regcache *regcache, int regnum)
+{
+  if (regnum == -1 || regnum <= ARC_LAST_REGNUM)
+    fetch_gregs (regcache, regnum);
+}
+
+/* Target operation: Store REGNUM register (all registers if REGNUM == -1)
+   to the target process from REGCACHE.  */
+
+void
+arc_linux_nat_target::store_registers (struct regcache *regcache, int regnum)
+{
+  if (regnum == -1 || regnum <= ARC_LAST_REGNUM)
+    store_gregs (regcache, regnum);
+}
+
+/* Copy general purpose register(s) from REGCACHE into regset GREGS.
+   This function is exported to proc-service.c  */
+
+void
+fill_gregset (const struct regcache *regcache,
+	      gdb_gregset_t *gregs, int regnum)
+{
+  struct gdbarch *gdbarch = regcache->arch ();
+  const struct regset *regset;
+
+  if (arc64_isa_reg_size (gdbarch) == 4)
+    regset = &arc32_linux_gregset;
+  else
+    perror_with_name (_("ARCv3 64-bit is not supported yet"));
+
+  arc_linux_collect_gregset (regset, regcache, regnum, gregs, 0);
+}
+
+/* Copy all the general purpose registers from regset GREGS into REGCACHE.
+   This function is exported to proc-service.c.  */
+
+void
+supply_gregset (struct regcache *regcache, const gdb_gregset_t *gregs)
+{
+  struct gdbarch *gdbarch = regcache->arch ();
+  const struct regset *regset;
+
+  if (arc64_isa_reg_size (gdbarch) == 4)
+    regset = &arc32_linux_gregset;
+  else
+    perror_with_name (_("ARCv3 64-bit is not supported yet"));
+
+  arc_linux_supply_gregset (regset, regcache, -1, gregs, 0);
+}
+
+/* ptrace for ARCv3 does not support floating point registers yet.  */
+
+void
+fill_fpregset (const struct regcache *regcache,
+	       gdb_fpregset_t *fpregsetp, int regnum)
+{
+  arc_linux_nat_debug_printf ("called");
+}
+
+void
+supply_fpregset (struct regcache *regcache, const gdb_fpregset_t *fpregsetp)
+{
+  arc_linux_nat_debug_printf ("called");
+}
+
+/* Implement the "read_description" method of linux_nat_target.  */
+
+const struct target_desc *
+arc_linux_nat_target::read_description ()
+{
+  struct gdbarch *gdbarch = current_inferior ()->arch ();
+  arc_arch_features features (arc64_isa_reg_size (gdbarch), ARC_ISA_ARCV3);
+  return arc_lookup_target_description (features);
+}
+
+/* As described in arc_linux_collect_gregset(), we need to write resume-PC
+   to ERET.  However by default GDB for native targets doesn't write
+   registers if they haven't been changed.  This is a callback called by
+   generic GDB, and in this callback we have to rewrite PC value so it
+   would force rewrite of register on target.  It seems that the only
+   other arch that utilizes this hook is x86/x86-64 for HW breakpoint
+   support.  But then, AFAIK no other arch has this stop_pc/eret
+   complexity.
+
+   No better way was found, other than this fake write of register value,
+   to force GDB into writing register to target.  Is there any?  */
+
+void
+arc_linux_nat_target::low_prepare_to_resume (struct lwp_info *lwp)
+{
+  /* When new processes and threads are created we do not have the address
+     space for them and calling get_thread_regcache will cause an internal
+     error in GDB.  It looks like that checking for last_resume_kind is the
+     sensible way to determine processes for which we cannot get regcache.
+     Ultimately, a better way would be removing the need for
+     low_prepare_to_resume in the first place.  */
+  if (lwp->last_resume_kind == resume_stop)
+    return;
+
+  struct regcache *regcache = get_thread_regcache (this, lwp->ptid);
+  struct gdbarch *gdbarch = regcache->arch ();
+
+  /* Read current PC value, then write it back.  It is required to call
+     invalidate(), otherwise GDB will note that new value is equal to old
+     value and will skip write.  */
+  ULONGEST new_pc;
+  regcache_cooked_read_unsigned (regcache, gdbarch_pc_regnum (gdbarch),
+				 &new_pc);
+  regcache->invalidate (gdbarch_pc_regnum (gdbarch));
+  regcache_cooked_write_unsigned (regcache, gdbarch_pc_regnum (gdbarch),
+				  new_pc);
+}
+
+/* Fetch the thread-local storage pointer for libthread_db.  Note that
+   this function is not called from GDB, but is called from libthread_db.
+   This is required to debug multithreaded applications with NPTL.  */
+
+ps_err_e
+ps_get_thread_area (struct ps_prochandle *ph, lwpid_t lwpid, int idx,
+		    void **base)
+{
+  arc_linux_nat_debug_printf ("called");
+
+  if (ptrace (PTRACE_GET_THREAD_AREA, lwpid, NULL, base) != 0)
+    return PS_ERR;
+
+  /* IDX is the bias from the thread pointer to the beginning of the
+     thread descriptor.  It has to be subtracted due to implementation
+     quirks in libthread_db.  */
+  *base = (void *) ((char *) *base - idx);
+
+  return PS_OK;
+}
+
+/* Suppress warning from -Wmissing-prototypes.  */
+void _initialize_arc_linux_nat ();
+void
+_initialize_arc_linux_nat ()
+{
+  /* Register the target.  */
+  linux_target = &the_arc_linux_nat_target;
+  add_inf_child_target (&the_arc_linux_nat_target);
+}

--- a/gdb/arc64-linux-tdep.c
+++ b/gdb/arc64-linux-tdep.c
@@ -28,6 +28,7 @@
 
 /* ARC header files.  */
 #include "opcodes/arc-dis.h"
+#include "arc64-linux-tdep.h"
 #include "arc64-tdep.h"
 #include "arch/arc.h"
 
@@ -269,6 +270,217 @@ arc_linux_skip_solib_resolver (struct gdbarch *gdbarch, CORE_ADDR pc)
     }
 }
 
+static const int arc32_linux_gregset_offsets[] = {
+  ARC32_GREGSET_REGISTER_OFFSET (23),	/* R0 */
+  ARC32_GREGSET_REGISTER_OFFSET (22),	/* R1 */
+  ARC32_GREGSET_REGISTER_OFFSET (21),	/* R2 */
+  ARC32_GREGSET_REGISTER_OFFSET (20),	/* R3 */
+  ARC32_GREGSET_REGISTER_OFFSET (19),	/* R4 */
+  ARC32_GREGSET_REGISTER_OFFSET (18),	/* R5 */
+  ARC32_GREGSET_REGISTER_OFFSET (17),	/* R6 */
+  ARC32_GREGSET_REGISTER_OFFSET (16),	/* R7 */
+  ARC32_GREGSET_REGISTER_OFFSET (15),	/* R8 */
+  ARC32_GREGSET_REGISTER_OFFSET (14),	/* R9 */
+  ARC32_GREGSET_REGISTER_OFFSET (13),	/* R10 */
+  ARC32_GREGSET_REGISTER_OFFSET (12),	/* R11 */
+  ARC32_GREGSET_REGISTER_OFFSET (11),	/* R12 */
+  ARC32_GREGSET_REGISTER_OFFSET (10),	/* R13 */
+  ARC32_GREGSET_REGISTER_OFFSET (37),	/* R14 */
+  ARC32_GREGSET_REGISTER_OFFSET (36),	/* R15 */
+  ARC32_GREGSET_REGISTER_OFFSET (35),	/* R16 */
+  ARC32_GREGSET_REGISTER_OFFSET (34),	/* R17 */
+  ARC32_GREGSET_REGISTER_OFFSET (33),	/* R18 */
+  ARC32_GREGSET_REGISTER_OFFSET (32),	/* R19 */
+  ARC32_GREGSET_REGISTER_OFFSET (31),	/* R20 */
+  ARC32_GREGSET_REGISTER_OFFSET (30),	/* R21 */
+  ARC32_GREGSET_REGISTER_OFFSET (29),	/* R22 */
+  ARC32_GREGSET_REGISTER_OFFSET (28),	/* R23 */
+  ARC32_GREGSET_REGISTER_OFFSET (27),	/* R24 */
+  ARC32_GREGSET_REGISTER_OFFSET (26),	/* R25 */
+  ARC_OFFSET_NO_REGISTER,		/* R26 */
+  ARC32_GREGSET_REGISTER_OFFSET (8),	/* R27 - FP */
+  ARC32_GREGSET_REGISTER_OFFSET (24),	/* R28 - SP */
+  ARC_OFFSET_NO_REGISTER,		/* R29 - ILINK */
+  ARC32_GREGSET_REGISTER_OFFSET (9),	/* R30 - GP */
+  ARC32_GREGSET_REGISTER_OFFSET (7),	/* R31 - BLINK */
+  ARC_OFFSET_NO_REGISTER,		/* R32 */
+  ARC_OFFSET_NO_REGISTER,		/* R33 */
+  ARC_OFFSET_NO_REGISTER,		/* R34 */
+  ARC_OFFSET_NO_REGISTER,		/* R35 */
+  ARC_OFFSET_NO_REGISTER,		/* R36 */
+  ARC_OFFSET_NO_REGISTER,		/* R37 */
+  ARC_OFFSET_NO_REGISTER,		/* R38 */
+  ARC_OFFSET_NO_REGISTER,		/* R39 */
+  ARC_OFFSET_NO_REGISTER,		/* R40 */
+  ARC_OFFSET_NO_REGISTER,		/* R41 */
+  ARC_OFFSET_NO_REGISTER,		/* R42 */
+  ARC_OFFSET_NO_REGISTER,		/* R43 */
+  ARC_OFFSET_NO_REGISTER,		/* R44 */
+  ARC_OFFSET_NO_REGISTER,		/* R45 */
+  ARC_OFFSET_NO_REGISTER,		/* R46 */
+  ARC_OFFSET_NO_REGISTER,		/* R47 */
+  ARC_OFFSET_NO_REGISTER,		/* R48 */
+  ARC_OFFSET_NO_REGISTER,		/* R49 */
+  ARC_OFFSET_NO_REGISTER,		/* R50 */
+  ARC_OFFSET_NO_REGISTER,		/* R51 */
+  ARC_OFFSET_NO_REGISTER,		/* R52 */
+  ARC_OFFSET_NO_REGISTER,		/* R53 */
+  ARC_OFFSET_NO_REGISTER,		/* R54 */
+  ARC_OFFSET_NO_REGISTER,		/* R55 */
+  ARC_OFFSET_NO_REGISTER,		/* R56 */
+  ARC_OFFSET_NO_REGISTER,		/* R57 */
+  ARC_OFFSET_NO_REGISTER,		/* R58 */
+  ARC_OFFSET_NO_REGISTER,		/* R59 */
+  ARC_OFFSET_NO_REGISTER,		/* R60 - LP_COUNT */
+  ARC_OFFSET_NO_REGISTER,		/* R61 - RESERVED */
+  ARC_OFFSET_NO_REGISTER,		/* R62 - LIMM */
+  ARC_OFFSET_NO_REGISTER,		/* R63 - PCL */
+  ARC_OFFSET_NO_REGISTER,		/* F0 */
+  ARC_OFFSET_NO_REGISTER,		/* F1 */
+  ARC_OFFSET_NO_REGISTER,		/* F2 */
+  ARC_OFFSET_NO_REGISTER,		/* F3 */
+  ARC_OFFSET_NO_REGISTER,		/* F4 */
+  ARC_OFFSET_NO_REGISTER,		/* F5 */
+  ARC_OFFSET_NO_REGISTER,		/* F6 */
+  ARC_OFFSET_NO_REGISTER,		/* F7 */
+  ARC_OFFSET_NO_REGISTER,		/* F8 */
+  ARC_OFFSET_NO_REGISTER,		/* F9 */
+  ARC_OFFSET_NO_REGISTER,		/* F10 */
+  ARC_OFFSET_NO_REGISTER,		/* F11 */
+  ARC_OFFSET_NO_REGISTER,		/* F12 */
+  ARC_OFFSET_NO_REGISTER,		/* F13 */
+  ARC_OFFSET_NO_REGISTER,		/* F14 */
+  ARC_OFFSET_NO_REGISTER,		/* F15 */
+  ARC_OFFSET_NO_REGISTER,		/* F16 */
+  ARC_OFFSET_NO_REGISTER,		/* F17 */
+  ARC_OFFSET_NO_REGISTER,		/* F18 */
+  ARC_OFFSET_NO_REGISTER,		/* F19 */
+  ARC_OFFSET_NO_REGISTER,		/* F20 */
+  ARC_OFFSET_NO_REGISTER,		/* F21 */
+  ARC_OFFSET_NO_REGISTER,		/* F22 */
+  ARC_OFFSET_NO_REGISTER,		/* F23 */
+  ARC_OFFSET_NO_REGISTER,		/* F24 */
+  ARC_OFFSET_NO_REGISTER,		/* F25 */
+  ARC_OFFSET_NO_REGISTER,		/* F26 */
+  ARC_OFFSET_NO_REGISTER,		/* F27 */
+  ARC_OFFSET_NO_REGISTER,		/* F28 */
+  ARC_OFFSET_NO_REGISTER,		/* F29 */
+  ARC_OFFSET_NO_REGISTER,		/* F30 */
+  ARC_OFFSET_NO_REGISTER,		/* F31 */
+  ARC32_GREGSET_REGISTER_OFFSET (39),	/* PC */
+  ARC32_GREGSET_REGISTER_OFFSET (5),	/* STATUS32 */
+  ARC32_GREGSET_REGISTER_OFFSET (1),	/* BTA */
+  ARC32_GREGSET_REGISTER_OFFSET (6)	/* ERET */
+};
+
+/* Populate REGCACHE with register REGNUM from BUF.  */
+
+static void
+supply_register (const struct regset *regset,
+		 struct regcache *regcache,
+		 int regnum,
+		 const gdb_byte *buf)
+{
+  const int *offsets = (const int *) regset->regmap;
+
+  /* Skip non-existing registers.  */
+  if ((offsets[regnum] == ARC_OFFSET_NO_REGISTER))
+    return;
+
+  regcache->raw_supply (regnum, buf + offsets[regnum]);
+}
+
+void
+arc_linux_supply_gregset (const struct regset *regset,
+			  struct regcache *regcache,
+			  int regnum, const void *gregs, size_t size)
+{
+  const bfd_byte *buf = (const bfd_byte *) gregs;
+
+  /* REGNUM == -1 means writing all the registers.  */
+  if (regnum == -1)
+    for (int reg = 0; reg <= ARC_LAST_REGNUM; reg++)
+      supply_register (regset, regcache, reg, buf);
+  else if (regnum <= ARC_LAST_REGNUM)
+    supply_register (regset, regcache, regnum, buf);
+  else
+    gdb_assert_not_reached ("Invalid regnum in arc_linux_supply_gregset.");
+}
+
+/* Populate BUF with register REGNUM from the REGCACHE.  */
+
+static void
+collect_register (const struct regset *regset,
+		  const struct regcache *regcache,
+		  struct gdbarch *gdbarch,
+		  int regnum,
+		  gdb_byte *buf)
+{
+  const int *offsets = (const int *) regset->regmap;
+  int offset;
+
+  /* Skip non-existing registers.  */
+  if (offsets[regnum] == ARC_OFFSET_NO_REGISTER)
+    return;
+
+  /* The address where the execution has stopped is in pseudo-register
+     STOP_PC.  However, when kernel code is returning from the exception,
+     it uses the value from ERET register.  Since, TRAP_S (the breakpoint
+     instruction) commits, the ERET points to the next instruction.  In
+     other words: ERET != STOP_PC.  To jump back from the kernel code to
+     the correct address, ERET must be overwritten by GDB's STOP_PC.  Else,
+     the program will continue at the address after the current instruction.
+     */
+  if (regnum == gdbarch_pc_regnum (gdbarch))
+    offset = offsets[ARC_ERET_REGNUM];
+  else
+    offset = offsets[regnum];
+  regcache->raw_collect (regnum, buf + offset);
+}
+
+void
+arc_linux_collect_gregset (const struct regset *regset,
+			   const struct regcache *regcache,
+			   int regnum, void *gregs, size_t size)
+{
+  gdb_byte *buf = (gdb_byte *) gregs;
+  struct gdbarch *gdbarch = regcache->arch ();
+
+  /* REGNUM == -1 means writing all the registers.  */
+  if (regnum == -1)
+    for (int reg = 0; reg <= ARC_LAST_REGNUM; reg++)
+      collect_register (regset, regcache, gdbarch, reg, buf);
+  else if (regnum <= ARC_LAST_REGNUM)
+    collect_register (regset, regcache, gdbarch, regnum, buf);
+  else
+    gdb_assert_not_reached ("Invalid regnum in arc_linux_collect_gregset.");
+}
+
+/* Linux regset definitions.  */
+
+const struct regset arc32_linux_gregset = {
+  arc32_linux_gregset_offsets,
+  arc_linux_supply_gregset,
+  arc_linux_collect_gregset,
+};
+
+/* Implement the `iterate_over_regset_sections` gdbarch method.  */
+
+static void
+arc32_linux_iterate_over_regset_sections (struct gdbarch *gdbarch,
+					  iterate_over_regset_sections_cb *cb,
+					  void *cb_data,
+					  const struct regcache *regcache)
+{
+  static_assert (ARC_LAST_REGNUM < ARRAY_SIZE (arc32_linux_gregset_offsets));
+
+  const int sizeof_gregset =
+	ARC_GREGSET_REGISTERS_NUMBER * arc64_isa_reg_size (gdbarch);
+
+  cb (".reg", sizeof_gregset, sizeof_gregset, &arc32_linux_gregset, NULL,
+      cb_data);
+}
+
 /* Initialization specific to Linux environment.  */
 
 static void
@@ -301,6 +513,13 @@ arc64_linux_init_osabi (struct gdbarch_info info, struct gdbarch *gdbarch)
   set_gdbarch_software_single_step (gdbarch, arc_linux_software_single_step);
   set_gdbarch_skip_trampoline_code (gdbarch, find_solib_trampoline_target);
   set_gdbarch_skip_solib_resolver (gdbarch, arc_linux_skip_solib_resolver);
+
+  // TODO: Reading of a core dump is not supported by HS6x yet.
+  if (arc64_isa_reg_size (gdbarch) == 4)
+    {
+      set_gdbarch_iterate_over_regset_sections
+	(gdbarch, arc32_linux_iterate_over_regset_sections);
+    }
 
   /* GNU/Linux uses SVR4-style shared libraries...  */
   set_solib_svr4_fetch_link_map_offsets (gdbarch,

--- a/gdb/arc64-linux-tdep.h
+++ b/gdb/arc64-linux-tdep.h
@@ -1,0 +1,59 @@
+/* Target dependent code for GNU/Linux ARC.
+
+   Copyright 2024 Free Software Foundation, Inc.
+
+   This file is part of GDB.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef ARC64_LINUX_TDEP_H
+#define ARC64_LINUX_TDEP_H
+
+#include "gdbarch.h"
+#include "regset.h"
+
+/* In user_regs_struct structure from include/uapi/asm/ptrace.h all registers
+   are declared with "unsigned long" type. That means that registers are dumped
+   differently for ARCv3 32-bit and ARCv3 64-bit targets:
+
+     1. For ARCv3 32-bit targets all registers are saved as 32-bit values.
+     2. For ARCv3 64-bit targets all registers are saved as 64-bit values
+        even if some of them are 32-bit registers (e.g., STATUS32).
+
+   That is why we assume that for ARCv3 64-bit targets all registers are dumped
+   as 64-bit values.  */
+
+#define ARC_GREGSET_REGISTERS_NUMBER 40
+#define ARC32_GREGSET_REGISTER_SIZE 4
+#define ARC64_GREGSET_REGISTER_SIZE 8
+#define ARC32_GREGSET_REGISTER_OFFSET(offset) \
+	((offset) * ARC32_GREGSET_REGISTER_SIZE)
+#define ARC64_GREGSET_REGISTER_OFFSET(offset) \
+	((offset) * ARC64_GREGSET_REGISTER_SIZE)
+
+extern const struct regset arc32_linux_gregset;
+
+/* Reads registers from the NT_PRSTATUS data array into the regcache.  */
+
+void arc_linux_supply_gregset (const struct regset *regset,
+			       struct regcache *regcache, int regnum,
+			       const void *gregs, size_t size);
+
+/* Writes registers from the regcache into the NT_PRSTATUS data array.  */
+
+void arc_linux_collect_gregset (const struct regset *regset,
+				const struct regcache *regcache,
+				int regnum, void *gregs, size_t size);
+
+#endif /* ARC64_LINUX_TDEP_H */

--- a/gdb/arc64-tdep.c
+++ b/gdb/arc64-tdep.c
@@ -2146,7 +2146,7 @@ arc64_gdbarch_init (struct gdbarch_info info, struct gdbarch_list *arches)
   set_gdbarch_breakpoint_kind_from_pc (gdbarch, arc_breakpoint_kind_from_pc);
   set_gdbarch_sw_breakpoint_from_kind (gdbarch, arc_sw_breakpoint_from_kind);
 
-  set_gdbarch_decr_pc_after_break (gdbarch, 2);
+  set_gdbarch_decr_pc_after_break (gdbarch, 0);
 
   set_gdbarch_frame_align (gdbarch, arc_frame_align);
 

--- a/gdb/configure.nat
+++ b/gdb/configure.nat
@@ -244,7 +244,14 @@ case ${gdb_host} in
 		;;
 	    arc)
 		# Host: ARC based machine running GNU/Linux
-		NATDEPFILES="${NATDEPFILES} arc-linux-nat.o"
+		case ${host_cpu} in
+		    arc)
+			NATDEPFILES="${NATDEPFILES} arc-linux-nat.o"
+			;;
+		    arc32|arc64)
+			NATDEPFILES="${NATDEPFILES} arc64-linux-nat.o"
+			;;
+		esac
 		;;
 	    arm)
 		# Host: ARM based machine running GNU/Linux

--- a/gdb/features/arc/v1-aux.c
+++ b/gdb/features/arc/v1-aux.c
@@ -30,5 +30,6 @@ create_feature_arc_v1_aux (struct target_desc *result, long regnum)
   tdesc_create_reg (feature, "lp_start", regnum++, 1, NULL, 32, "code_ptr");
   tdesc_create_reg (feature, "lp_end", regnum++, 1, NULL, 32, "code_ptr");
   tdesc_create_reg (feature, "bta", regnum++, 1, NULL, 32, "code_ptr");
+  tdesc_create_reg (feature, "eret", regnum++, 1, NULL, 32, "code_ptr");
   return regnum;
 }

--- a/gdb/features/arc/v1-aux.xml
+++ b/gdb/features/arc/v1-aux.xml
@@ -28,4 +28,5 @@
   <reg name="lp_start" bitsize="32" type="code_ptr"/>
   <reg name="lp_end"   bitsize="32" type="code_ptr"/>
   <reg name="bta"      bitsize="32" type="code_ptr"/>
+  <reg name="eret"     bitsize="32" type="code_ptr"/>
 </feature>

--- a/gdb/features/arc/v2-aux.c
+++ b/gdb/features/arc/v2-aux.c
@@ -34,5 +34,6 @@ create_feature_arc_v2_aux (struct target_desc *result, long regnum)
   tdesc_create_reg (feature, "lp_start", regnum++, 1, NULL, 32, "code_ptr");
   tdesc_create_reg (feature, "lp_end", regnum++, 1, NULL, 32, "code_ptr");
   tdesc_create_reg (feature, "bta", regnum++, 1, NULL, 32, "code_ptr");
+  tdesc_create_reg (feature, "eret", regnum++, 1, NULL, 32, "code_ptr");
   return regnum;
 }

--- a/gdb/features/arc/v2-aux.xml
+++ b/gdb/features/arc/v2-aux.xml
@@ -32,4 +32,5 @@
   <reg name="lp_start" bitsize="32" type="code_ptr"/>
   <reg name="lp_end"   bitsize="32" type="code_ptr"/>
   <reg name="bta"      bitsize="32" type="code_ptr"/>
+  <reg name="eret"     bitsize="32" type="code_ptr"/>
 </feature>


### PR DESCRIPTION
First 2 patches are just small fixes for existing ARCv2/v3 ports. The seconds one ([arc64: gdb: Set decr_pc_after_break to 0](https://github.com/foss-for-synopsys-dwc-arc-processors/binutils-gdb/commit/87e0eade728dca05e25d5a0d16ce64d4fabb80a2)) is essnetial for native GDB for ARCv3 - it will crash without that fix.

Native GDB port includes support of reading core dumps and debugging Linux applications by native GDB for ARCv3 32-bit targets.

A new file is added - `arc64-linux-nat.c`. It contains code for native Linux implementation of GDB. It is almost the same as `arc-linux-nat.c` for ARCv1/2 targets but with small changes related to ARCv3. Core dumps support also is almost the same as for ARCv2 except different registers order.

Original structure and comments from ARCv2 implementation are preserved to simplify further merging of ARCv2 and ARCv3 implementations.

Consider this `faulty.c` example:

```c
#include <stdio.h>

int main()
{
        int n = *((int *) 0x12345678);
        printf("%d\n", n);
        return 0;
}
```

Compile it:

```
arc32-linux-gnu-gcc -g3 -O2 faulty.c -o faulty
```

Then on target:

```
# ulimit -c unlimited
# ./faulty
potentially unexpected fatal signal 11.
Path: /root/faulty
CPU: 0 PID: 127 Comm: faulty Not tainted 5.16.0 #9
Invalid Read @ 0x12345678 by insn @ 0x102c6
  @off 0x102c6 in [/root/faulty]  VMA: 0x00010000 to 0x00011000
ECR: 0x00050100 EFA: 0x12345678 ERET: 0x000102c6
STAT: 0x80080a82 [IE U     ]   BTA: 0x000102c4
 SP: 0x5fb5fdc0  FP: 0x00000000 BLK: 0x20044be6
r00: 0x00000001 r01: 0x5fb5fe94 r02: 0x5fb5fe9c
r03: 0x000102c4 r04: 0x00000000 r05: 0x00000000
r06: 0x5fb5fdd0 r07: 0x201511b8 r08: 0x00000000
r09: 0x00000000 r10: 0x20000ae4 r11: 0x000182af
r12: 0x20043648 r13: 0x00000003 r14: 0x5fb5fe94
r15: 0x00000001 r16: 0x00013f28 r17: 0x00000000
r18: 0x000102c4 r19: 0x5fb5fe9c r20: 0x20021e88
r21: 0x20022000 r22: 0x00013f28 r23: 0x00000000
r24: 0x00000008 r25: 0x00000000
Segmentation fault (core dumped)
# ls
core      faulty    faulty.c
# gdb -q -ex "set sysroot /" -ex "set solib-search-path /" faulty
Reading symbols from faulty...
(gdb) core core
warning: exec file is newer than core file.
[New LWP 127]
warning: Unable to find libthread_db matching inferior's thread library, thread debugging will not be available.
Core was generated by `./faulty'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  main () at faulty.c:6
6               printf("%d\n", n);
(gdb) bt
#0  main () at faulty.c:6
(gdb) i r
r0             0x1                 1
r1             0x5fb5fe94          1605762708
r2             0x5fb5fe9c          1605762716
r3             0x102c4             66244
r4             0x0                 0
r5             0x0                 0
r6             0x5fb5fdd0          1605762512
r7             0x201511b8          538251704
r8             0x0                 0
r9             0x0                 0
r10            0x20000ae4          536873700
r11            0x182af             98991
r12            0x20043648          537146952
r13            0x3                 3
r14            0x5fb5fe94          1605762708
r15            0x1                 1
r16            0x13f28             81704
r17            0x0                 0
r18            0x102c4             66244
r19            0x5fb5fe9c          1605762716
r20            0x20021e88          537009800
r21            0x20022000          537010176
r22            0x13f28             81704
--Type <RET> for more, q to quit, c to continue without paging--
r23            0x0                 0
r24            0x8                 8
r25            0x0                 0
r26            <unavailable>
fp             0x0                 0x0
sp             0x5fb5fdc0          0x5fb5fdc0
ilink          <unavailable>
gp             0x2001f880          0x2001f880
blink          0x20044be6          0x20044be6 <__libc_start_call_main+94>
pcl            <unavailable>
pc             0x102c6             0x102c6 <main+2>
status32       0x80080a82          [ E=1 U C Z RB=0 AD IE ]
bta            0x102c4             0x102c4 <main>
eret           0x102c6             0x102c6 <main+2>
(gdb) 
```
