### PR TITLE
fixup! arc64: gdb: Add support of native GDB for ARCv3 32-bit targets

### DIFF
--- a/gdb/configure.nat
+++ b/gdb/configure.nat
@@ -245,7 +245,7 @@ case ${gdb_host} in
 	    arc)
 		# Host: ARC based machine running GNU/Linux
 		case ${host_cpu} in
-		    arc)
+		    arc|arceb)
 			NATDEPFILES="${NATDEPFILES} arc-linux-nat.o"
 			;;
 		    arc32|arc64)


### PR DESCRIPTION
Add missing host_cpu value for big endian ARC. The native GDB for big endian targets does not build without it.