### PR TITLE
ld: Initialize no_lto variable in LTO tests

### DIFF
--- a/ld/testsuite/ld-plugin/lto.exp
+++ b/ld/testsuite/ld-plugin/lto.exp
@@ -45,6 +45,7 @@ proc restore_notify { } {
 
 set lto_fat ""
 set lto_no_fat ""
+set no_lto ""
 if { [check_lto_fat_available] } {
   set lto_fat "-ffat-lto-objects"
   set lto_no_fat "-fno-fat-lto-objects"


### PR DESCRIPTION
no_lto must be initialized in lto.exp as lto_fat and lto_no_fat. Otherwise, the testsuite will fail in some cases because of using of an undefined variable. This patch will be sent to upstream shortly.