### PR TITLE
Fix readline in GDB for building using GCC 15

### DIFF
--- a/readline/readline/signals.c
+++ b/readline/readline/signals.c
@@ -1,6 +1,6 @@
 /* signals.c -- signal handling support for readline. */
 
-/* Copyright (C) 1987-2017 Free Software Foundation, Inc.
+/* Copyright (C) 1987-2021 Free Software Foundation, Inc.
 
    This file is part of the GNU Readline Library (Readline), a library
    for reading lines of text with interactive input and history editing.      
@@ -48,23 +48,11 @@
 
 #if defined (HANDLE_SIGNALS)
 
-#if !defined (RETSIGTYPE)
-#  if defined (VOID_SIGHANDLER)
-#    define RETSIGTYPE void
-#  else
-#    define RETSIGTYPE int
-#  endif /* !VOID_SIGHANDLER */
-#endif /* !RETSIGTYPE */
-
-#if defined (VOID_SIGHANDLER)
-#  define SIGHANDLER_RETURN return
-#else
-#  define SIGHANDLER_RETURN return (0)
-#endif
+#define SIGHANDLER_RETURN return
 
 /* This typedef is equivalent to the one for Function; it allows us
    to say SigHandler *foo = signal (SIGKILL, SIG_IGN); */
-typedef RETSIGTYPE SigHandler ();
+typedef void SigHandler (int);
 
 #if defined (HAVE_POSIX_SIGNALS)
 typedef struct sigaction sighandler_cxt;
@@ -78,12 +66,12 @@ typedef struct { SigHandler *sa_handler; int sa_mask, sa_flags; } sighandler_cxt
 #  define SA_RESTART 0
 #endif
 
-static SigHandler *rl_set_sighandler PARAMS((int, SigHandler *, sighandler_cxt *));
-static void rl_maybe_set_sighandler PARAMS((int, SigHandler *, sighandler_cxt *));
-static void rl_maybe_restore_sighandler PARAMS((int, sighandler_cxt *));
+static SigHandler *rl_set_sighandler (int, SigHandler *, sighandler_cxt *);
+static void rl_maybe_set_sighandler (int, SigHandler *, sighandler_cxt *);
+static void rl_maybe_restore_sighandler (int, sighandler_cxt *);
 
-static RETSIGTYPE rl_signal_handler PARAMS((int));
-static RETSIGTYPE _rl_handle_signal PARAMS((int));
+static void rl_signal_handler (int);
+static void _rl_handle_signal (int);
      
 /* Exported variables for use by applications. */
 
@@ -136,7 +124,7 @@ void *_rl_sigcleanarg;
 /* Readline signal handler functions. */
 
 /* Called from RL_CHECK_SIGNALS() macro to run signal handling code. */
-RETSIGTYPE
+void
 _rl_signal_handler (int sig)
 {
   _rl_caught_signal = 0;	/* XXX */
@@ -163,7 +151,7 @@ _rl_signal_handler (int sig)
   SIGHANDLER_RETURN;
 }
 
-static RETSIGTYPE
+static void
 rl_signal_handler (int sig)
 {
   _rl_caught_signal = sig;
@@ -173,7 +161,7 @@ rl_signal_handler (int sig)
 /* This is called to handle a signal when it is safe to do so (out of the
    signal handler execution path). Called by _rl_signal_handler for all the
    signals readline catches except SIGWINCH. */
-static RETSIGTYPE
+static void
 _rl_handle_signal (int sig)
 {
   int block_sig;
@@ -222,6 +210,9 @@ _rl_handle_signal (int sig)
   switch (sig)
     {
     case SIGINT:
+      /* We will end up blocking SIGTTOU while we are resetting the tty, so
+	 watch out for this if it causes problems. We could prevent this by
+	 setting block_sig to 1 without modifying SET. */
       _rl_reset_completion_state ();
       rl_free_line_state ();
 #if defined (READLINE_CALLBACKS)
@@ -242,8 +233,11 @@ _rl_handle_signal (int sig)
 	 this even if we've been stopped on SIGTTOU, since we handle signals
 	 when we have returned from the signal handler and the signal is no
 	 longer blocked. */
-      sigaddset (&set, SIGTTOU);
-      block_sig = 1;
+      if (block_sig == 0)
+	{
+	  sigaddset (&set, SIGTTOU);
+	  block_sig = 1;
+	}
 #  endif
 #endif /* SIGTSTP */
    /* Any signals that should be blocked during cleanup should go here. */
@@ -285,19 +279,6 @@ _rl_handle_signal (int sig)
 
       /* We don't have to bother unblocking the signal because we are not
 	 running in a signal handler context. */
-#if 0
-#if defined (HAVE_POSIX_SIGNALS)
-      /* Make sure this signal is not blocked when we resend it to the
-	 calling application. */
-      sigemptyset (&set);
-      sigprocmask (SIG_BLOCK, (sigset_t *)NULL, &set);
-      sigdelset (&set, sig);
-#else /* !HAVE_POSIX_SIGNALS */
-#  if defined (HAVE_BSD_SIGNALS)
-      omask = sigblock (0);
-#  endif /* HAVE_BSD_SIGNALS */
-#endif /* !HAVE_POSIX_SIGNALS */
-#endif
 
 #if defined (__EMX__)
       signal (sig, SIG_ACK);
@@ -311,16 +292,6 @@ _rl_handle_signal (int sig)
 
       /* We don't need to modify the signal mask now that this is not run in
 	 a signal handler context. */
-#if 0
-      /* Let the signal that we just sent through if it is blocked.  */
-#if defined (HAVE_POSIX_SIGNALS)
-      sigprocmask (SIG_SETMASK, &set, (sigset_t *)NULL);
-#else /* !HAVE_POSIX_SIGNALS */
-#  if defined (HAVE_BSD_SIGNALS)
-      sigsetmask (omask & ~(sigmask (sig)));
-#  endif /* HAVE_BSD_SIGNALS */
-#endif /* !HAVE_POSIX_SIGNALS */
-#endif
 
       rl_reset_after_signal ();      
     }
@@ -330,7 +301,7 @@ _rl_handle_signal (int sig)
 }
 
 #if defined (SIGWINCH)
-static RETSIGTYPE
+static void
 rl_sigwinch_handler (int sig)
 {
   SigHandler *oh;

--- a/readline/readline/tcap.h
+++ b/readline/readline/tcap.h
@@ -46,14 +46,14 @@ extern char *UP, *BC;
 
 extern short ospeed;
 
-extern int tgetent ();
-extern int tgetflag ();
-extern int tgetnum ();
-extern char *tgetstr ();
+extern int tgetent (char *bp, const char *name);
+extern int tgetflag (char *id);
+extern int tgetnum (char *id);
+extern char *tgetstr (char *id, char **area);
 
-extern int tputs ();
+extern int tputs (const char *str, int affcnt, int (*putc)(int));
 
-extern char *tgoto ();
+extern char *tgoto (const char *cap, int col, int row);
 
 #endif /* HAVE_TERMCAP_H */
 


### PR DESCRIPTION
These 2 patches fix `readline` so it could be built using GCC 15:

1. First one is just a part of [this patch](https://github.com/bminor/binutils-gdb/commit/425f843d58c5748f23776759f4f1b55869ba2b89) from upstream. The patch was prepared and introduced in Crosstool-NG.
2. Second one is https://github.com/bminor/binutils-gdb/commit/5c87b330e910f8be1443c881fd16a70e685f1f2f from upstream.

Both patches reside in Crosstool-NG but its scripts do not apply patches for sources from a custom repository. Thus, they should be included in this release.