### PR TITLE
arc: Add support of a raw binary format to disassembler

### DIFF
--- a/binutils/testsuite/binutils-all/arc/binary.s
+++ b/binutils/testsuite/binutils-all/arc/binary.s
@@ -1,0 +1,5 @@
+.cpu HS
+.section .text
+.global __start
+__start:
+    mov r0, r1

--- a/binutils/testsuite/binutils-all/arc/objdump.exp
+++ b/binutils/testsuite/binutils-all/arc/objdump.exp
@@ -47,6 +47,26 @@ proc do_objfile { srcfile } {
     return $objfile
 }
 
+# Create a plain binary file with content of .text section.
+proc do_binary { objfile } {
+    global OBJCOPY
+    global OBJCOPYFLAGS
+
+    set binary "$objfile.bin"
+
+    if {[binutils_run $OBJCOPY "$OBJCOPYFLAGS -O binary -j .text $objfile $binary"] != ""} then {
+	return
+    }
+
+    if [is_remote host] {
+	set binary [remote_download host $binary]
+    } else {
+	set binary $binary
+    }
+
+    return $binary
+}
+
 # Ensure that disassembler output includes EXPECTED lines.
 proc check_assembly { testname objfile expected { disas_flags "" } } {
     global OBJDUMP
@@ -104,3 +124,9 @@ check_assembly "arc hex printing" $thexobj \
     {st\s*r0,\[r1,0xfffffff7\]} "-Mhex"
 check_assembly "arc normal printing" $thexobj \
     {st\s*r0,\[r1,-9\]}
+
+# Check that objdump can disassemble raw binary files.
+set objfile [do_objfile binary.s]
+set binary [do_binary $objfile]
+check_assembly "arc binary" $binary \
+    {mov\s*r0,r1} "-m HS -Mcpu=hs -EL -b binary -D"

--- a/opcodes/arc-dis.c
+++ b/opcodes/arc-dis.c
@@ -1086,6 +1086,7 @@ print_insn_arc (bfd_vma memaddr,
   struct arc_operand_iterator iter;
   struct arc_disassemble_info *arc_infop;
   bool rpcl = false, rset = false;
+  bool code_section;
 
   if (info->private_data == NULL)
     {
@@ -1099,6 +1100,18 @@ print_insn_arc (bfd_vma memaddr,
   highbyte = info->endian == BFD_ENDIAN_LITTLE ? 1 : 0;
   lowbyte = info->endian == BFD_ENDIAN_LITTLE ? 0 : 1;
 
+  if (info->section)
+    {
+      struct bfd *abfd = info->section->owner;
+      /* Treat .data section for "binary" format as a code section.  */
+      if (abfd && strcmp (bfd_get_target (abfd), "binary") == 0)
+	  code_section = true;
+      else
+	  code_section = info->section->flags & SEC_CODE;
+    }
+  else
+    code_section = true;
+
   /* This variable may be set by the instruction decoder.  It suggests
      the number of bytes objdump should display on a single line.  If
      the instruction decoder sets this, it should always set it to
@@ -1110,8 +1123,7 @@ print_insn_arc (bfd_vma memaddr,
      8 and bytes_per_chunk is 4, the output will look like this:
      00:   00000000 00000000
      with the chunks displayed according to "display_endian".  */
-  if (info->section
-      && !(info->section->flags & SEC_CODE))
+  if (!code_section)
     {
       /* This is not a CODE section.  */
       switch (info->section->size)
@@ -1144,8 +1156,7 @@ print_insn_arc (bfd_vma memaddr,
       return -1;
     }
 
-  if (info->section
-      && !(info->section->flags & SEC_CODE))
+  if (!code_section)
     {
       /* Data section.  */
       unsigned long data;


### PR DESCRIPTION
There is a single .data section in a raw binary which should be treated as a code section. However, ARC disassembler is not aware of it and treats everything as data.

This patch fixes this behavior and adds a corresponding test.